### PR TITLE
fix Ops signature; move matrixOps out of Ops group

### DIFF
--- a/R/generic-spec.R
+++ b/R/generic-spec.R
@@ -17,6 +17,8 @@ as_S3_generic <- function(x) {
     name <- find_base_name(x)
     if (name %in% names(base_ops)) {
       return(base_ops[[name]])
+    } else if (name %in% names(base_matrix_ops)) {
+      return(base_matrix_ops[[name]])
     } else if (!is.na(name) && is_internal_generic(name)) {
       return(S3_generic(x, name))
     }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -118,6 +118,11 @@ matrixOps.S7_object <- function(x, y) {
   base_matrix_ops[[.Generic]](x, y)
 }
 
+if(getRversion() < "4.4.0")
+matrixOps.S7_object <- function(e1, e2) {
+  base_matrix_ops[[.Generic]](e1, e2)
+}
+
 #' @rawNamespace if (getRversion() >= "4.3.0") S3method(chooseOpsMethod, S7_object)
 chooseOpsMethod.S7_object <- function(x, y, mx, my, cl, reverse) TRUE
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -102,16 +102,21 @@ methods::setOldClass(c("S7_method", "function", "S7_object"))
 
 
 # Create generics for double dispatch base Ops
-base_ops <- lapply(setNames(, unlist(group_generics()[c("Ops", "matrixOps")])),
-                   new_generic, dispatch_args = c("x", "y"))
+base_ops <- lapply(setNames(, group_generics()$Ops),
+                   new_generic, dispatch_args = c("e1", "e2"))
 
 #' @export
 Ops.S7_object <- function(e1, e2) {
   base_ops[[.Generic]](e1, e2)
 }
 
+base_matrix_ops <- lapply(setNames(, group_generics()$matrixOps),
+                          new_generic, dispatch_args = c("x", "y"))
+
 #' @rawNamespace if (getRversion() >= "4.3.0") S3method(matrixOps, S7_object)
-matrixOps.S7_object <- Ops.S7_object
+matrixOps.S7_object <- function(x, y) {
+  base_matrix_ops[[.Generic]](x, y)
+}
 
 #' @rawNamespace if (getRversion() >= "4.3.0") S3method(chooseOpsMethod, S7_object)
 chooseOpsMethod.S7_object <- function(x, y, mx, my, cl, reverse) TRUE

--- a/tests/testthat/test-base-r.R
+++ b/tests/testthat/test-base-r.R
@@ -61,8 +61,8 @@ test_that("Ops generics dispatch to S7 methods", {
 
   ## Test Ops
   ClassX <- new_class("ClassX")
-  method(`+`, list(class_any, ClassX))   <- function(x, y) "class_any + ClassX"
-  method(`+`, list(ClassX, class_any))   <- function(x, y) "ClassX + class_any"
+  method(`+`, list(class_any, ClassX))   <- function(e1, e2) "class_any + ClassX"
+  method(`+`, list(ClassX, class_any))   <- function(e1, e2) "ClassX + class_any"
   method(`%*%`, list(ClassX, class_any)) <- function(x, y) "ClassX %*% class_any"
   method(`%*%`, list(class_any, ClassX)) <- function(x, y) "class_any %*% ClassX"
 
@@ -96,7 +96,7 @@ test_that("Ops generics dispatch to S7 methods", {
   `+.foo`   <- function(e1, e2) paste(class(e1), "+"     , class(e2))
   `%*%.foo` <- function(x, y)   paste(class(x) , "%*%"   , class(y))
   Ops.bar   <- function(e1, e2) paste(class(e1), .Generic, class(e2))
-  matrixOps.bar   <- function(e1, e2) paste(class(e1), .Generic, class(e2))
+  matrixOps.bar   <- function(x, y) paste(class(x), .Generic, class(y))
 
   foo <- structure("", class = "foo")
   bar <- structure("", class = "bar")

--- a/tests/testthat/test-generic-spec.R
+++ b/tests/testthat/test-generic-spec.R
@@ -15,5 +15,5 @@ test_that("can standardise generics", {
 test_that("base ops use S7 shim", {
   expect_equal(as_generic(`+`), base_ops[["+"]])
   if(getRversion() >= "4.3.0")
-    expect_equal(as_generic(`%*%`), base_ops[["%*%"]])
+    expect_equal(as_generic(`%*%`), base_matrix_ops[["%*%"]])
 })

--- a/tests/testthat/test-method-register.R
+++ b/tests/testthat/test-method-register.R
@@ -51,7 +51,7 @@ describe("method registration", {
     foo <- new_class("foo")
     bar <- new_class("bar")
 
-    method(`+`, list(foo, bar)) <- function(x, y) "foobar"
+    method(`+`, list(foo, bar)) <- function(e1, e2) "foobar"
     expect_equal(foo() + bar(), "foobar")
 
     if(getRversion() >= "4.3.0") {


### PR DESCRIPTION
This PR: 

1. Changes the S7-internal Ops group generics signature from `x, y` to `e1, e2`, matching base R.
2. Moves matrixOps generics out of the Ops dispatch code path. `matrixOps.S7_object` is no longer an alias of `Ops.S7_object`, and `Ops.S7_object` no longer dispatches `%*%`.

closes #321