### PR TITLE
Update URLs in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,8 +23,8 @@ Description: A new object oriented programming system designed to be a successor
   which includes representatives from R-Core, 'Bioconductor', 
   'Posit'/'tidyverse', and the wider R community.
 License: MIT + file LICENSE
-URL: https://github.com/rconsortium/OOP-WG/,
-    https://rconsortium.github.io/OOP-WG/
+URL: https://github.com/rconsortium/S7/,
+    https://rconsortium.github.io/S7/
 BugReports: https://github.com/rconsortium/OOP-WG/issues
 Depends: 
     R (>= 3.5.0)


### PR DESCRIPTION
Note: The pkgdown site link is broken on CRAN. Is it possible to set up a redirect on github pages to the new URL? I think you'd have to create a new repository with that name, which would break the OTHER redirect, so probably not worth it.