### PR TITLE
Store the S7 methods table as an attribute of the S3 methods table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # S7 (development version)
 
+* External methods are now registered using an attribute of the S3 methods 
+  table rather than an element of that environment. This prevents a warning
+  being generated during the "code/documentation mismatches" check in
+  `R CMD check` (#342).
+
 * `class_missing` and `class_any` can now be unioned with `|` (#337).
 
 * `new_object()` works better when custom property setters modify other 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,8 +5,6 @@
   being generated during the "code/documentation mismatches" check in
   `R CMD check` (#342).
 
-* `new_object()` now correctly runs the validator from abstract parent classes 
-
 * `new_object()` no longer accepts `NULL` as `.parent`.
 
 * `new_object()` now correctly runs the validator from abstract parent classes

--- a/tests/testthat/test-external-generic.R
+++ b/tests/testthat/test-external-generic.R
@@ -2,12 +2,12 @@ test_that("can get and append methods", {
   external_methods_reset("S7")
   on.exit(external_methods_reset("S7"), add = TRUE)
 
-  expect_equal(external_methods_get("S7"), list())
+  expect_equal(S7_methods_table("S7"), list())
 
   bar <- new_external_generic("foo", "bar", "x")
   external_methods_add("S7", bar, list(), function() {})
   expect_equal(
-    external_methods_get("S7"),
+    S7_methods_table("S7"),
     list(
       list(
         generic = bar,

--- a/vignettes/packages.Rmd
+++ b/vignettes/packages.Rmd
@@ -45,7 +45,7 @@ If you export a class, you must also set the `package` argument, ensuring that c
 
 You should document generics like regular functions (since they are!).
 If you expect others to create their own methods for your generic, you may want to include an section describing the the properties that you expect all methods to have.
-We plan to provide an easy way to list all methods for a generic, but have not yet implemented it.
+We plan to provide a an easy way to all methods for a generic, but have not yet implemented it.
 You can track progress at <https://github.com/RConsortium/OOP-WG/issues/167>.
 
 We don't currently have any recommendations on documenting methods.

--- a/vignettes/packages.Rmd
+++ b/vignettes/packages.Rmd
@@ -45,7 +45,7 @@ If you export a class, you must also set the `package` argument, ensuring that c
 
 You should document generics like regular functions (since they are!).
 If you expect others to create their own methods for your generic, you may want to include an section describing the the properties that you expect all methods to have.
-We plan to provide a an easy way to all methods for a generic, but have not yet implemented it.
+We plan to provide an easy way to list all methods for a generic, but have not yet implemented it.
 You can track progress at <https://github.com/RConsortium/OOP-WG/issues/167>.
 
 We don't currently have any recommendations on documenting methods.


### PR DESCRIPTION
This prevents it from being listed in `functions_in_S3_table` (https://github.com/wch/r-source/blob/16c4fbf48efb4d43ef5dccadc86576100edd85b4/src/library/tools/R/QC.R#L370-L383) and later generating a warning when calling `formals` on each element of that list.

Fixes #342