### PR TITLE
Disallow `NULL` as a `.parent` in `new_object()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # S7 (development version)
 
-* `new_object()` now correctly runs the validator from abstract parent classes 
+* `new_object()` no longer accepts `NULL` as `.parent`.
+
+* `new_object()` now correctly runs the validator from abstract parent classes
   (#329).
 
 * `new_property()` gains a `validator` argument that allows you to specify

--- a/R/class.R
+++ b/R/class.R
@@ -245,7 +245,8 @@ new_object <- function(.parent, ...) {
   args <- list(...)
   nms <- names(args)
 
-  object <- .parent %||% class_construct(class@parent)
+  # TODO: Some type checking on `.parent`?
+  object <- .parent
   attr(object, "S7_class") <- class
   class(object) <- class_dispatch(class)
 

--- a/R/constructor.R
+++ b/R/constructor.R
@@ -2,14 +2,7 @@ new_constructor <- function(parent, properties) {
   arg_info <- constructor_args(parent, properties)
   self_args <- as_names(arg_info$self, named = TRUE)
 
-  if (identical(parent, S7_object)) {
-    return(new_function(
-      args = missing_args(arg_info$self),
-      body = new_call("new_object", c(list(NULL), self_args)),
-      env = asNamespace("S7")
-    ))
-  }
-  if (is_class(parent) && parent@abstract) {
+  if (identical(parent, S7_object) || (is_class(parent) && parent@abstract)) {
     return(new_function(
       args = missing_args(arg_info$self),
       body = new_call("new_object", c(list(quote(S7_object())), self_args)),

--- a/tests/testthat/_snaps/constructor.md
+++ b/tests/testthat/_snaps/constructor.md
@@ -4,13 +4,13 @@
       new_constructor(S7_object, list())
     Output
       function () 
-      new_object(NULL)
+      new_object(S7_object())
       <environment: namespace:S7>
     Code
       new_constructor(S7_object, as_properties(list(x = class_numeric, y = class_numeric)))
     Output
       function (x = class_missing, y = class_missing) 
-      new_object(NULL, x = x, y = y)
+      new_object(S7_object(), x = x, y = y)
       <environment: namespace:S7>
     Code
       foo <- new_class("foo", parent = class_character)

--- a/tests/testthat/test-constructor.R
+++ b/tests/testthat/test-constructor.R
@@ -71,7 +71,7 @@ test_that("can use `...` in parent constructor", {
   foo <- new_class(
     "foo",
     properties = list(x = class_list),
-    constructor = function(...) new_object(NULL, x = list(...))
+    constructor = function(...) new_object(S7_object(), x = list(...))
   )
 
   expect_snapshot(

--- a/vignettes/classes-objects.Rmd
+++ b/vignettes/classes-objects.Rmd
@@ -229,13 +229,13 @@ range <- new_class("range",
     end = class_numeric
   ),
   constructor = function(x) {
-    new_object(NULL, start = min(x, na.rm = TRUE), end = max(x, na.rm = TRUE))
+    new_object(S7_object(), start = min(x, na.rm = TRUE), end = max(x, na.rm = TRUE))
   }
 )
 
 range(c(10, 5, 0, 2, 5, 7))
 ```
 
-A constructor must always end with a call to `new_object()`. The first argument to `new_object()` should be an object of the `parent` class, or `NULL`, if there's no parent (as here). That argument should be followed by one named argument for each property.
+A constructor must always end with a call to `new_object()`. The first argument to `new_object()` should be an object of the `parent` class (if you haven't specified a `parent` argument to `new_class()`, then you should use `S7_object()` as the parent here). That argument should be followed by one named argument for each property.
 
 There's one drawback of custom constructors that you should be aware: any subclass will also require a custom constructor.


### PR DESCRIPTION
I think this tightens things up a bit. It is technically breaking as `NULL` was allowed before. I think we should either do this or set `.parent = S7_object()` as the default (which would parallel `parent = S7_object` as the default in `new_class()`).

If we did `.parent = S7_object()`, then I'd be ok with this optional argument coming before the named `...` in this instance because if you have a `.parent` that takes arguments, then those arguments would be supplied _before_ the class arguments when the constructor is generated, so you end up with something like:

```r
# good
my_class <- function(x, y) {
  new_object(parent(x = x), y = y)
}

# harder to read
my_class <- function(x, y) {
  new_object(y = y, .parent = parent(x = x))
}
```