### PR TITLE
Add default upcasting `convert()` method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # S7 (development version)
 
+* `convert()` now provides a default method to transform a parent class instance 
+  into a subclass, enabling class construction from a prototype (#444).
+
 * The default object constructor returned by `new_class()` has been updated. 
   It now accepts missing and lazy (promise) property defaults. Additionally, 
   all custom property setters are now consistently invoked by the default 

--- a/R/convert.R
+++ b/R/convert.R
@@ -92,7 +92,7 @@ convert <- function(from, to, ...) {
       stop("Unreachable")
     }
     from
-  } else if (inherits(from, class_dispatch(to))) {
+  } else if (inherits(from, setdiff(class_dispatch(to), "S7_object"))) {
     # We're up-casting, using `from` as a prototype/seed when constructing `to`.
     # Essentially, we copy over property values from `from` and supply them as
     # arguments to the `to` constructor.

--- a/R/convert.R
+++ b/R/convert.R
@@ -103,7 +103,7 @@ convert <- function(from, to, ...) {
       stop("Unreachable")
     }
     from
-  } else if (inherits(from, setdiff(class_dispatch(to), "S7_object"))) {
+  } else if (is_parent_instance(from, to)) {
     # We're up-casting, using `from` as a prototype/seed when constructing `to`.
     # Essentially, we copy over property values from `from` and supply them as
     # arguments to the `to` constructor.
@@ -152,4 +152,8 @@ on_load_make_convert_generic <- function() {
     name = "convert",
     dispatch_args = c("from", "to")
   )
+}
+
+is_parent_instance <- function(x, class) {
+  inherits(x, setdiff(class_dispatch(class), "S7_object"))
 }

--- a/R/convert.R
+++ b/R/convert.R
@@ -16,9 +16,13 @@
 #'   to work because those methods will return `classParent` objects, not
 #'   `classChild` objects.
 #'
-#' `convert()` provides a default implementation when `from` inherits from
-#' `to`. This default strips any properties that `from` possesses that `to`
-#' does not.
+#' `convert()` provides two default implementations:
+#'
+#' 1. When `from` inherits from `to`, it strips any properties that `from`
+#'    possesses that `to` does not (downcasting).
+#' 2. When `to` is a subclass of `from`'s class, it creates a new object of
+#'    class `to`, copying over existing properties from `from` and initializing
+#'    new properties of `to` (upcasting).
 #'
 #' If you are converting an object solely for the purposes of accessing a method
 #' on a superclass, you probably want [super()] instead. See its docs for more
@@ -31,7 +35,8 @@
 #'
 #' @param from An S7 object to convert.
 #' @param to An S7 class specification, passed to [as_class()].
-#' @param ... Other arguments passed to custom `convert()` methods.
+#' @param ... Other arguments passed to custom `convert()` methods. For upcasting,
+#'   these can be used to override existing properties or set new ones.
 #' @return Either `from` coerced to class `to`, or an error if the coercion
 #'   is not possible.
 #' @export
@@ -39,9 +44,15 @@
 #' foo1 <- new_class("foo1", properties = list(x = class_integer))
 #' foo2 <- new_class("foo2", foo1, properties = list(y = class_double))
 #'
-#' # S7 provides a default implementation for coercing an object to one of
-#' # its parent classes:
+#' # Downcasting: S7 provides a default implementation for coercing an object
+#' # to one of its parent classes:
 #' convert(foo2(x = 1L, y = 2), to = foo1)
+#'
+#' # Upcasting: S7 also provides a default implementation for coercing an object
+#' # to one of its child classes:
+#' convert(foo1(x = 1L), to = foo2)
+#' convert(foo1(x = 1L), to = foo2, y = 2.5)  # Set new property
+#' convert(foo1(x = 1L), to = foo2, x = 2L, y = 2.5)  # Override existing and set new
 #'
 #' # For all other cases, you'll need to provide your own.
 #' try(convert(foo1(x = 1L), to = class_integer))

--- a/R/convert.R
+++ b/R/convert.R
@@ -127,8 +127,7 @@ convert <- function(from, to, ...) {
     from_prop_names <- setdiff(from_prop_names, names(user_args))
 
     # Extract property values from 'from'
-    from_prop_values <- lapply(setNames(, from_prop_names),
-                               function(name) prop(from, name))
+    from_prop_values <- props(from, from_prop_names)
 
     # Combine property values with user-supplied arguments
     constructor_args <- c(from_prop_values, user_args)

--- a/R/property.R
+++ b/R/property.R
@@ -392,6 +392,8 @@ prop_exists <- function(object, name) {
 #'
 #' @importFrom stats setNames
 #' @inheritParams prop
+#' @param names A character vector of property names to retrieve. Default is all
+#'   properties.
 #' @returns A named list of property values.
 #' @export
 #' @examples
@@ -405,13 +407,12 @@ prop_exists <- function(object, name) {
 #' props(lexington)
 #' props(lexington) <- list(height = 14, name = "Lexington")
 #' lexington
-props <- function(object) {
+props <- function(object, names = prop_names(object)) {
   check_is_S7(object)
-  prop_names <- prop_names(object)
-  if (length(prop_names) == 0) {
-    list()
+  if (length(names) == 0) {
+    structure(list(), names = character(0))
   } else {
-    setNames(lapply(prop_names, prop, object = object), prop_names)
+    setNames(lapply(names, prop, object = object), names)
   }
 }
 #' @rdname props

--- a/R/property.R
+++ b/R/property.R
@@ -479,3 +479,7 @@ as_property <- function(x, name, i) {
     new_property(x, name = name)
   }
 }
+
+prop_is_read_only <- function(prop) {
+  is.function(prop$getter) && !is.function(prop$setter)
+}

--- a/man/convert.Rd
+++ b/man/convert.Rd
@@ -11,7 +11,8 @@ convert(from, to, ...)
 
 \item{to}{An S7 class specification, passed to \code{\link[=as_class]{as_class()}}.}
 
-\item{...}{Other arguments passed to custom \code{convert()} methods.}
+\item{...}{Other arguments passed to custom \code{convert()} methods. For upcasting,
+these can be used to override existing properties or set new ones.}
 }
 \value{
 Either \code{from} coerced to class \code{to}, or an error if the coercion
@@ -32,9 +33,14 @@ to work because those methods will return \code{classParent} objects, not
 \code{classChild} objects.
 }
 
-\code{convert()} provides a default implementation when \code{from} inherits from
-\code{to}. This default strips any properties that \code{from} possesses that \code{to}
-does not.
+\code{convert()} provides two default implementations:
+\enumerate{
+\item When \code{from} inherits from \code{to}, it strips any properties that \code{from}
+possesses that \code{to} does not (downcasting).
+\item When \code{to} is a subclass of \code{from}'s class, it creates a new object of
+class \code{to}, copying over existing properties from \code{from} and initializing
+new properties of \code{to} (upcasting).
+}
 
 If you are converting an object solely for the purposes of accessing a method
 on a superclass, you probably want \code{\link[=super]{super()}} instead. See its docs for more
@@ -49,9 +55,15 @@ functions/generics in S3, and to \code{as()}/\code{setAs()} in S4.
 foo1 <- new_class("foo1", properties = list(x = class_integer))
 foo2 <- new_class("foo2", foo1, properties = list(y = class_double))
 
-# S7 provides a default implementation for coercing an object to one of
-# its parent classes:
+# Downcasting: S7 provides a default implementation for coercing an object
+# to one of its parent classes:
 convert(foo2(x = 1L, y = 2), to = foo1)
+
+# Upcasting: S7 also provides a default implementation for coercing an object
+# to one of its child classes:
+convert(foo1(x = 1L), to = foo2)
+convert(foo1(x = 1L), to = foo2, y = 2.5)  # Set new property
+convert(foo1(x = 1L), to = foo2, x = 2L, y = 2.5)  # Override existing and set new
 
 # For all other cases, you'll need to provide your own.
 try(convert(foo1(x = 1L), to = class_integer))

--- a/man/props.Rd
+++ b/man/props.Rd
@@ -6,7 +6,7 @@
 \alias{set_props}
 \title{Get/set multiple properties}
 \usage{
-props(object)
+props(object, names = prop_names(object))
 
 props(object) <- value
 
@@ -14,6 +14,9 @@ set_props(object, ...)
 }
 \arguments{
 \item{object}{An object from a S7 class}
+
+\item{names}{A character vector of property names to retrieve. Default is all
+properties.}
 
 \item{value}{A named list of values. The object is checked for validity
 only after all replacements are performed.}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -62,3 +62,10 @@ defer <- function(expr, frame = parent.frame(), after = FALSE) {
   thunk <- as.call(list(function() expr))
   do.call(on.exit, list(thunk, TRUE, after), envir = frame)
 }
+
+# always returns a named list, even in the empty case.
+named_list <- function(...) {
+  x <- list(...)
+  names(x) <- names2(x)
+  x
+}

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -44,6 +44,38 @@ describe("fallback convert", {
     expect_equal(attr(obj, "y"), NULL)
   })
 
+  it("can convert to subclass", {
+    Foo <- new_class("Foo", properties = list(x = class_numeric))
+    Bar <- new_class("Bar", Foo, properties = list(y = class_numeric))
+
+    foo <- Foo(x = 1)
+
+    # Basic conversion
+    bar <- convert(foo, Bar)
+    expect_s3_class(bar, c("Bar", "Foo", "S7_object"))
+    expect_equal(S7_class(bar), Bar)
+    expect_equal(bar@x, 1)
+    expect_equal(bar@y, numeric(0))
+
+    # Overriding existing property
+    bar <- convert(foo, Bar, x = 2)
+    expect_equal(bar@x, 2)
+
+    # Setting new property
+    bar <- convert(foo, Bar, y = 2)
+    expect_equal(bar@x, 1)
+    expect_equal(bar@y, 2)
+
+    # Setting both properties
+    bar <- convert(foo, Bar, y = 2, x = 3)
+    expect_equal(bar@x, 3)
+    expect_equal(bar@y, 2)
+
+    # Error on converting to unrelated class
+    Unrelated <- new_class("Unrelated", properties = list(z = class_character))
+    expect_error(convert(foo, Unrelated), "Can't find method")
+  })
+
   it("can convert to S3 class", {
     factor2 <- new_class("factor2", class_factor, properties = list(x = class_double))
     obj <- convert(factor2(1, "x", x = 1), to = class_factor)

--- a/tests/testthat/test-property.R
+++ b/tests/testthat/test-property.R
@@ -188,7 +188,7 @@ describe("property access", {
   it("can with property-less object", {
     x <- new_class("x")()
     expect_equal(prop_names(x), character())
-    expect_equal(props(x), list())
+    expect_equal(props(x), named_list())
     expect_equal(prop_exists(x, "y"), FALSE)
   })
 
@@ -197,7 +197,7 @@ describe("property access", {
     attr(x, "extra") <- 1
 
     expect_equal(prop_names(x), character())
-    expect_equal(props(x), list())
+    expect_equal(props(x), named_list())
     expect_false(prop_exists(x, "extra"))
   })
 })


### PR DESCRIPTION
Closes #430.
Maybe also closes #420?