### PR TITLE
Include Settable Properties in Default Constructor

### DIFF
--- a/R/class.R
+++ b/R/class.R
@@ -267,9 +267,11 @@ new_object <- function(.parent, ...) {
   # TODO: Some type checking on `.parent`?
   object <- .parent
 
-  attrs <- c(list(class = class_dispatch(class), S7_class = class),
-             static_prop_vals,
-             attributes(object))
+  attrs <- c(
+    list(class = class_dispatch(class), S7_class = class),
+    static_prop_vals,
+    attributes(object)
+  )
   attrs <- attrs[!duplicated(names(attrs))]
   attributes(object) <- attrs
 

--- a/R/class.R
+++ b/R/class.R
@@ -257,7 +257,8 @@ new_object <- function(.parent, ...) {
     stop("All arguments to `new_object(...)` must be named")
   }
 
-  dynamic_setter_prop_names <- names(Filter(\(p) is.function(p$setter), class@properties))
+  dynamic_setter_prop_names <- names(Filter(function(p) is.function(p$setter),
+                                            class@properties))
 
   static_prop_vals <- args[setdiff(names(args), dynamic_setter_prop_names)]
   dynamic_prop_vals <- args[intersect(names(args), dynamic_setter_prop_names)]

--- a/R/constructor.R
+++ b/R/constructor.R
@@ -64,12 +64,6 @@ constructor_args <- function(parent, properties = list()) {
     function(name) prop_default(properties[[name]]))
   )
 
-  is_dots <- vlapply(self_args, identical, quote(...))
-  if (any(is_dots)) {
-    self_args[is_dots] <- NULL
-    append(self_args, after = which.max(is_dots)-1) <- alist(... = )
-  }
-
   list(parent = parent_args,
        self = self_args)
 }
@@ -91,8 +85,4 @@ as_names <- function(x, named = FALSE) {
     names(x) <- x
   }
   lapply(x, as.name)
-}
-
-`append<-` <- function(x, after = length(x), value) {
-  append(x, value, after)
 }

--- a/R/constructor.R
+++ b/R/constructor.R
@@ -1,7 +1,7 @@
 new_constructor <- function(parent, properties) {
   properties <- as_properties(properties)
   arg_info <- constructor_args(parent, properties)
-  self_args <- as_names(names(arg_info$self), named = TRUE, unnamed = "...")
+  self_args <- as_names(names(arg_info$self), named = TRUE)
 
   if (identical(parent, S7_object) || (is_class(parent) && parent@abstract)) {
     return(new_function(
@@ -86,16 +86,11 @@ new_call <- function(call, args) {
   as.call(c(list(as.name(call)), args))
 }
 
-as_names <- function(x, named = FALSE, unnamed = "...") {
+as_names <- function(x, named = FALSE) {
   if (named) {
     names(x) <- x
   }
-  out <- lapply(x, as.name)
-  if (!is.null(nms <- names(out)) && length(unnamed)) {
-    nms[nms %in% unnamed] <- ""
-    names(out) <- nms
-  }
-  out
+  lapply(x, as.name)
 }
 
 `append<-` <- function(x, after = length(x), value) {

--- a/R/constructor.R
+++ b/R/constructor.R
@@ -48,9 +48,10 @@ new_constructor <- function(parent, properties) {
 constructor_args <- function(parent, properties = list()) {
   parent_args <- formals(class_constructor(parent))
 
+  # Remove read-only properties
+  properties <- properties[!vlapply(properties, prop_is_read_only)]
+
   self_arg_nms <- names2(properties)
-  # Remove dynamic arguments
-  self_arg_nms <- self_arg_nms[vlapply(properties, function(x) is.null(x$getter))]
 
   if (is_class(parent) && !parent@abstract) {
     # Remove any parent properties; can't use parent_args() since the constructor

--- a/R/constructor.R
+++ b/R/constructor.R
@@ -67,7 +67,7 @@ constructor_args <- function(parent, properties = list()) {
   is_dots <- vlapply(self_args, identical, quote(...))
   if (any(is_dots)) {
     self_args[is_dots] <- NULL
-    append(self_args) <- alist(... = )
+    append(self_args, after = which.max(is_dots)-1) <- alist(... = )
   }
 
   list(parent = parent_args,

--- a/R/constructor.R
+++ b/R/constructor.R
@@ -6,7 +6,12 @@ new_constructor <- function(parent, properties) {
   if (identical(parent, S7_object) || (is_class(parent) && parent@abstract)) {
     return(new_function(
       args = arg_info$self,
-      body = new_call("new_object", c(list(quote(S7_object())), self_args)),
+      body = as.call(c(quote(`{`),
+        # Force all promises here so that any errors are signaled from
+        # the constructor() call instead of the new_object() call.
+        unname(self_args),
+        new_call("new_object", c(list(quote(S7_object())), self_args))
+      )),
       env = asNamespace("S7")
     ))
   }

--- a/R/constructor.R
+++ b/R/constructor.R
@@ -1,7 +1,7 @@
 new_constructor <- function(parent, properties) {
   properties <- as_properties(properties)
   arg_info <- constructor_args(parent, properties)
-  self_args <- as_names(names(arg_info$self), named = TRUE)
+  self_args <- as_names(names(arg_info$self), named = TRUE, unnamed = "...")
 
   if (identical(parent, S7_object) || (is_class(parent) && parent@abstract)) {
     return(new_function(
@@ -86,11 +86,16 @@ new_call <- function(call, args) {
   as.call(c(list(as.name(call)), args))
 }
 
-as_names <- function(x, named = FALSE) {
+as_names <- function(x, named = FALSE, unnamed = "...") {
   if (named) {
     names(x) <- x
   }
-  lapply(x, as.name)
+  out <- lapply(x, as.name)
+  if (!is.null(nms <- names(out)) && length(unnamed)) {
+    nms[nms %in% unnamed] <- ""
+    names(out) <- nms
+  }
+  out
 }
 
 `append<-` <- function(x, after = length(x), value) {

--- a/R/constructor.R
+++ b/R/constructor.R
@@ -67,7 +67,7 @@ constructor_args <- function(parent, properties = list()) {
   is_dots <- vlapply(self_args, identical, quote(...))
   if (any(is_dots)) {
     self_args[is_dots] <- NULL
-    append(self_args, after = which.max(is_dots)-1) <- alist(... = )
+    append(self_args) <- alist(... = )
   }
 
   list(parent = parent_args,

--- a/R/constructor.R
+++ b/R/constructor.R
@@ -64,6 +64,12 @@ constructor_args <- function(parent, properties = list()) {
     function(name) prop_default(properties[[name]]))
   )
 
+  is_dots <- vlapply(self_args, identical, quote(...))
+  if (any(is_dots)) {
+    self_args[is_dots] <- NULL
+    append(self_args, after = which.max(is_dots)-1) <- alist(... = )
+  }
+
   list(parent = parent_args,
        self = self_args)
 }
@@ -85,4 +91,8 @@ as_names <- function(x, named = FALSE) {
     names(x) <- x
   }
   lapply(x, as.name)
+}
+
+`append<-` <- function(x, after = length(x), value) {
+  append(x, value, after)
 }

--- a/R/property.R
+++ b/R/property.R
@@ -173,7 +173,7 @@ new_property <- function(class = class_any,
   out
 }
 
-check_prop_default <- function(default, class) {
+check_prop_default <- function(default, class, error_call = sys.call(-1)) {
   if (is.null(default)) {
     return() # always valid.
   }
@@ -186,11 +186,11 @@ check_prop_default <- function(default, class) {
   if (is.symbol(default)) {
     if (identical(default, quote(...))) {
       # The meaning of a `...` prop default needs discussion
-      stop.parent("`default` cannot be `...`")
+      stop(simpleError("`default` cannot be `...`", error_call))
     }
     if (identical(default, quote(expr =))) {
       # The meaning of a missing prop default needs discussion
-      stop.parent("`default` cannot be missing")
+      stop(simpleError("`default` cannot be missing", error_call))
     }
 
     # other symbols are treated as promises
@@ -203,7 +203,7 @@ check_prop_default <- function(default, class) {
   msg <- sprintf("`default` must be an instance of %s, not a %s",
                  class_desc(class), obj_desc(default))
 
-  stop.parent(msg)
+  stop(simpleError(msg, error_call))
 }
 
 stop.parent <- function(..., call = sys.call(-2)) {

--- a/R/property.R
+++ b/R/property.R
@@ -33,9 +33,11 @@
 #'   your code can assume that `value` has known type.
 #' @param default When an object is created and the property is not supplied,
 #'   what should it default to? If `NULL`, it defaults to the "empty" instance
-#'   of `class`. This can also be a quoted call, which then becomes a standard
-#'   function promise in the default constructor, evaluated at the time the
-#'   object is constructed.
+#'   of `class`. Quoted calls become standard function argument promises in the
+#'   default constructor, evaluated at the time the object is constructed. A
+#'   value of `quote(...)` indicates that the property is not a named argument
+#'   in the constructor, and it is not set unless explicitly supplied. The
+#'   default value for the unset property in that case is `NULL`.
 #' @param name Property name, primarily used for error messages. Generally
 #'   don't need to set this here, as it's more convenient to supply as a
 #'   the element name when defining a list of properties. If both `name`
@@ -71,7 +73,12 @@
 #' args(clock)
 #'
 #' # These can be useful if you want to deprecate a property
-#' person <- new_class("person", properties = list(
+#' # For example, say, at first you define
+#' Person <- new_class("Person", properties = list(
+#'   firstName = class_character
+#' ))
+#' # Then, to deprecate `firstName` and rename it to `first_name`
+#' Person <- new_class("Person", properties = list(
 #'   first_name = class_character,
 #'   firstName = new_property(
 #'      getter = function(self) {
@@ -82,12 +89,14 @@
 #'        warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
 #'        self@first_name <- value
 #'        self
-#'      }
+#'      },
+#'      default = quote(...)
 #'    )
 #' ))
-#' hadley <- person(first_name = "Hadley")
-#' hadley@firstName
-#' hadley@firstName <- "John"
+#' hadley <- Person(firstName = "Hadley")   # warning
+#' hadley <- Person(first_name = "Hadley")
+#' hadley@firstName                      # warning
+#' hadley@firstName <- "John"            # warning
 #' hadley@first_name
 #'
 #' # Properties can have default values that are quoted calls.

--- a/R/property.R
+++ b/R/property.R
@@ -479,3 +479,7 @@ as_property <- function(x, name, i) {
     new_property(x, name = name)
   }
 }
+
+prop_is_read_only <- function(prop) {
+  is.function(prop$getter) && !is.function(prop$setter)
+}

--- a/R/property.R
+++ b/R/property.R
@@ -10,6 +10,9 @@
 #' behaviour when modified. Dynamic properties are not included as an argument
 #' to the default class constructor.
 #'
+#' See the "Properties: Common Patterns" section in `vignette("class-objects")`
+#' for more examples.
+#'
 #' @param class Class that the property must be an instance of.
 #'   See [as_class()] for details.
 #' @param getter An optional function used to get the value. The function
@@ -69,78 +72,6 @@
 #' # argument to the default constructor
 #' try(clock(now = 10))
 #' args(clock)
-#'
-#' # These can be useful if you want to deprecate a property
-#' person <- new_class("person", properties = list(
-#'   first_name = class_character,
-#'   firstName = new_property(
-#'      getter = function(self) {
-#'        warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
-#'        self@first_name
-#'      },
-#'      setter = function(self, value) {
-#'        if(is.null(value)) {
-#'          return(self)
-#'        }
-#'        warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
-#'        self@first_name <- value
-#'        self
-#'      }
-#'    )
-#' ))
-#' hadley <- person(firstName = "Hadley")   # Warning
-#' hadley <- person(first_name = "Hadley")
-#' hadley@firstName                         # Warning
-#' hadley@firstName <- "John"               # Warning
-#' hadley@first_name
-#'
-#' # Properties can have default values that are quoted calls.
-#' # These become standard function promises in the default constructor,
-#' # evaluated at the time the object is constructed.
-#' stopwatch <- new_class("stopwatch", properties = list(
-#'   starttime = new_property(class = class_POSIXct, default = quote(Sys.time())),
-#'   totaltime = new_property(getter = function(self)
-#'     difftime(Sys.time(), self@starttime, units = "secs"))
-#' ))
-#' args(stopwatch)
-#' round(stopwatch()@totaltime)
-#' round(stopwatch(Sys.time() - 1)@totaltime)
-#'
-#' # You can make a property required by the constructor either by:
-#' # - relying on the validator to error with the default value, or by
-#' # - setting the property default to a quoted error call.
-#' Person <- new_class("Person", properties = list(
-#'   name = new_property(class_character, validator = function(value) {
-#'     if (length(value) != 1 || is.na(value) || value == "")
-#'       "must be a non-empty string"
-#'   }))
-#' )
-#' try(Person())
-#' try(Person(1)) # class_character$validator() is also checked.
-#' Person("Alice")
-#'
-#' Person <- new_class("Person", properties = list(
-#'   name = new_property(class_character,
-#'                       default = quote(stop("@name is required")))
-#' ))
-#' try(Person())
-#' Person("Alice")
-#'
-#' # You can mark a property as read-only after construction by
-#' # providing a custom setter.
-#' Person <- new_class("Person", properties = list(
-#'   birth_date = new_property(
-#'     class_Date,
-#'     setter = function(self, value) {
-#'       if(!is.null(self@birth_date)) {
-#'         stop("@birth_date is read-only", call. = FALSE)
-#'       }
-#'       self@birth_date <- as.Date(value)
-#'       self
-#'     }
-#' )))
-#' person <- Person("1999-12-31")
-#' try(person@birth_date <- "2000-01-01")
 new_property <- function(class = class_any,
                          getter = NULL,
                          setter = NULL,

--- a/R/property.R
+++ b/R/property.R
@@ -546,3 +546,7 @@ as_property <- function(x, name, i) {
 prop_is_read_only <- function(prop) {
   is.function(prop$getter) && !is.function(prop$setter)
 }
+
+prop_has_setter <- function(prop) is.function(prop$setter)
+
+prop_is_dynamic <- function(prop) is.function(prop$getter)

--- a/R/property.R
+++ b/R/property.R
@@ -79,15 +79,19 @@
 #'        self@first_name
 #'      },
 #'      setter = function(self, value) {
+#'        if(is.null(value)) {
+#'          return(self)
+#'        }
 #'        warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
 #'        self@first_name <- value
 #'        self
 #'      }
 #'    )
 #' ))
+#' hadley <- person(firstName = "Hadley")   # Warning
 #' hadley <- person(first_name = "Hadley")
-#' hadley@firstName
-#' hadley@firstName <- "John"
+#' hadley@firstName                         # Warning
+#' hadley@firstName <- "John"               # Warning
 #' hadley@first_name
 #'
 #' # Properties can have default values that are quoted calls.
@@ -102,11 +106,22 @@
 #' round(stopwatch()@totaltime)
 #' round(stopwatch(Sys.time() - 1)@totaltime)
 #'
-#' # Properties can also have a 'missing' default value, making them
-#' # required arguments to the default constructor.
-#' # You can generate a missing arg with `quote(expr =)` or `rlang::missing_arg()`
+#' # You can make a property required by the constructor either by:
+#' # - relying on the validator to error with the default value, or by
+#' # - setting the property default to a quoted error call.
 #' Person <- new_class("Person", properties = list(
-#'   name = new_property(class_character, default = quote(expr = ))
+#'   name = new_property(class_character, validator = function(value) {
+#'     if (length(value) != 1 || is.na(value) || value == "")
+#'       "must be a non-empty string"
+#'   }))
+#' )
+#' try(Person())
+#' try(Person(1)) # class_character$validator() is also checked.
+#' Person("Alice")
+#'
+#' Person <- new_class("Person", properties = list(
+#'   name = new_property(class_character,
+#'                       default = quote(stop("@name is required")))
 #' ))
 #' try(Person())
 #' Person("Alice")

--- a/R/property.R
+++ b/R/property.R
@@ -125,6 +125,22 @@
 #' ))
 #' try(Person())
 #' Person("Alice")
+#'
+#' # You can mark a property as read-only after construction by
+#' # providing a custom setter.
+#' Person <- new_class("Person", properties = list(
+#'   birth_date = new_property(
+#'     class_Date,
+#'     setter = function(self, value) {
+#'       if(!is.null(self@birth_date)) {
+#'         stop("@birth_date is read-only", call. = FALSE)
+#'       }
+#'       self@birth_date <- as.Date(value)
+#'       self
+#'     }
+#' )))
+#' person <- Person("1999-12-31")
+#' try(person@birth_date <- "2000-01-01")
 new_property <- function(class = class_any,
                          getter = NULL,
                          setter = NULL,

--- a/R/property.R
+++ b/R/property.R
@@ -33,11 +33,9 @@
 #'   your code can assume that `value` has known type.
 #' @param default When an object is created and the property is not supplied,
 #'   what should it default to? If `NULL`, it defaults to the "empty" instance
-#'   of `class`. Quoted calls become standard function argument promises in the
-#'   default constructor, evaluated at the time the object is constructed. A
-#'   value of `quote(...)` indicates that the property is not a named argument
-#'   in the constructor, and it is not set unless explicitly supplied. The
-#'   default value for the unset property in that case is `NULL`.
+#'   of `class`. This can also be a quoted call, which then becomes a standard
+#'   function promise in the default constructor, evaluated at the time the
+#'   object is constructed.
 #' @param name Property name, primarily used for error messages. Generally
 #'   don't need to set this here, as it's more convenient to supply as a
 #'   the element name when defining a list of properties. If both `name`
@@ -73,12 +71,7 @@
 #' args(clock)
 #'
 #' # These can be useful if you want to deprecate a property
-#' # For example, say, at first you define
-#' Person <- new_class("Person", properties = list(
-#'   firstName = class_character
-#' ))
-#' # Then, to deprecate `firstName` and rename it to `first_name`
-#' Person <- new_class("Person", properties = list(
+#' person <- new_class("person", properties = list(
 #'   first_name = class_character,
 #'   firstName = new_property(
 #'      getter = function(self) {
@@ -89,14 +82,12 @@
 #'        warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
 #'        self@first_name <- value
 #'        self
-#'      },
-#'      default = quote(...)
+#'      }
 #'    )
 #' ))
-#' hadley <- Person(firstName = "Hadley")   # warning
-#' hadley <- Person(first_name = "Hadley")
-#' hadley@firstName                      # warning
-#' hadley@firstName <- "John"            # warning
+#' hadley <- person(first_name = "Hadley")
+#' hadley@firstName
+#' hadley@firstName <- "John"
 #' hadley@first_name
 #'
 #' # Properties can have default values that are quoted calls.

--- a/man/new_property.Rd
+++ b/man/new_property.Rd
@@ -100,15 +100,19 @@ person <- new_class("person", properties = list(
        self@first_name
      },
      setter = function(self, value) {
+       if(is.null(value)) {
+         return(self)
+       }
        warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
        self@first_name <- value
        self
      }
    )
 ))
+hadley <- person(firstName = "Hadley")   # Warning
 hadley <- person(first_name = "Hadley")
-hadley@firstName
-hadley@firstName <- "John"
+hadley@firstName                         # Warning
+hadley@firstName <- "John"               # Warning
 hadley@first_name
 
 # Properties can have default values that are quoted calls.
@@ -123,11 +127,22 @@ args(stopwatch)
 round(stopwatch()@totaltime)
 round(stopwatch(Sys.time() - 1)@totaltime)
 
-# Properties can also have a 'missing' default value, making them
-# required arguments to the default constructor.
-# You can generate a missing arg with `quote(expr =)` or `rlang::missing_arg()`
+# You can make a property required by the constructor either by:
+# - relying on the validator to error with the default value, or by
+# - setting the property default to a quoted error call.
 Person <- new_class("Person", properties = list(
-  name = new_property(class_character, default = quote(expr = ))
+  name = new_property(class_character, validator = function(value) {
+    if (length(value) != 1 || is.na(value) || value == "")
+      "must be a non-empty string"
+  }))
+)
+try(Person())
+try(Person(1)) # class_character$validator() is also checked.
+Person("Alice")
+
+Person <- new_class("Person", properties = list(
+  name = new_property(class_character,
+                      default = quote(stop("@name is required")))
 ))
 try(Person())
 Person("Alice")

--- a/man/new_property.Rd
+++ b/man/new_property.Rd
@@ -41,11 +41,9 @@ your code can assume that \code{value} has known type.}
 
 \item{default}{When an object is created and the property is not supplied,
 what should it default to? If \code{NULL}, it defaults to the "empty" instance
-of \code{class}. Quoted calls become standard function argument promises in the
-default constructor, evaluated at the time the object is constructed. A
-value of \code{quote(...)} indicates that the property is not a named argument
-in the constructor, and it is not set unless explicitly supplied. The
-default value for the unset property in that case is \code{NULL}.}
+of \code{class}. This can also be a quoted call, which then becomes a standard
+function promise in the default constructor, evaluated at the time the
+object is constructed.}
 
 \item{name}{Property name, primarily used for error messages. Generally
 don't need to set this here, as it's more convenient to supply as a
@@ -94,12 +92,7 @@ try(clock(now = 10))
 args(clock)
 
 # These can be useful if you want to deprecate a property
-# For example, say, at first you define
-Person <- new_class("Person", properties = list(
-  firstName = class_character
-))
-# Then, to deprecate `firstName` and rename it to `first_name`
-Person <- new_class("Person", properties = list(
+person <- new_class("person", properties = list(
   first_name = class_character,
   firstName = new_property(
      getter = function(self) {
@@ -110,14 +103,12 @@ Person <- new_class("Person", properties = list(
        warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
        self@first_name <- value
        self
-     },
-     default = quote(...)
+     }
    )
 ))
-hadley <- Person(firstName = "Hadley")   # warning
-hadley <- Person(first_name = "Hadley")
-hadley@firstName                      # warning
-hadley@firstName <- "John"            # warning
+hadley <- person(first_name = "Hadley")
+hadley@firstName
+hadley@firstName <- "John"
 hadley@first_name
 
 # Properties can have default values that are quoted calls.

--- a/man/new_property.Rd
+++ b/man/new_property.Rd
@@ -41,9 +41,11 @@ your code can assume that \code{value} has known type.}
 
 \item{default}{When an object is created and the property is not supplied,
 what should it default to? If \code{NULL}, it defaults to the "empty" instance
-of \code{class}. This can also be a quoted call, which then becomes a standard
-function promise in the default constructor, evaluated at the time the
-object is constructed.}
+of \code{class}. Quoted calls become standard function argument promises in the
+default constructor, evaluated at the time the object is constructed. A
+value of \code{quote(...)} indicates that the property is not a named argument
+in the constructor, and it is not set unless explicitly supplied. The
+default value for the unset property in that case is \code{NULL}.}
 
 \item{name}{Property name, primarily used for error messages. Generally
 don't need to set this here, as it's more convenient to supply as a
@@ -92,7 +94,12 @@ try(clock(now = 10))
 args(clock)
 
 # These can be useful if you want to deprecate a property
-person <- new_class("person", properties = list(
+# For example, say, at first you define
+Person <- new_class("Person", properties = list(
+  firstName = class_character
+))
+# Then, to deprecate `firstName` and rename it to `first_name`
+Person <- new_class("Person", properties = list(
   first_name = class_character,
   firstName = new_property(
      getter = function(self) {
@@ -103,12 +110,14 @@ person <- new_class("person", properties = list(
        warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
        self@first_name <- value
        self
-     }
+     },
+     default = quote(...)
    )
 ))
-hadley <- person(first_name = "Hadley")
-hadley@firstName
-hadley@firstName <- "John"
+hadley <- Person(firstName = "Hadley")   # warning
+hadley <- Person(first_name = "Hadley")
+hadley@firstName                      # warning
+hadley@firstName <- "John"            # warning
 hadley@first_name
 
 # Properties can have default values that are quoted calls.

--- a/man/new_property.Rd
+++ b/man/new_property.Rd
@@ -146,4 +146,20 @@ Person <- new_class("Person", properties = list(
 ))
 try(Person())
 Person("Alice")
+
+# You can mark a property as read-only after construction by
+# providing a custom setter.
+Person <- new_class("Person", properties = list(
+  birth_date = new_property(
+    class_Date,
+    setter = function(self, value) {
+      if(!is.null(self@birth_date)) {
+        stop("@birth_date is read-only", call. = FALSE)
+      }
+      self@birth_date <- as.Date(value)
+      self
+    }
+)))
+person <- Person("1999-12-31")
+try(person@birth_date <- "2000-01-01")
 }

--- a/man/new_property.Rd
+++ b/man/new_property.Rd
@@ -62,6 +62,9 @@ By specifying a \code{getter} and/or \code{setter}, you can make the property
 "dynamic" so that it's computed when accessed or has some non-standard
 behaviour when modified. Dynamic properties are not included as an argument
 to the default class constructor.
+
+See the "Properties: Common Patterns" section in \code{vignette("class-objects")}
+for more examples.
 }
 \examples{
 # Simple properties store data inside an object
@@ -90,76 +93,4 @@ try(my_clock@now <- 10)
 # argument to the default constructor
 try(clock(now = 10))
 args(clock)
-
-# These can be useful if you want to deprecate a property
-person <- new_class("person", properties = list(
-  first_name = class_character,
-  firstName = new_property(
-     getter = function(self) {
-       warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
-       self@first_name
-     },
-     setter = function(self, value) {
-       if(is.null(value)) {
-         return(self)
-       }
-       warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
-       self@first_name <- value
-       self
-     }
-   )
-))
-hadley <- person(firstName = "Hadley")   # Warning
-hadley <- person(first_name = "Hadley")
-hadley@firstName                         # Warning
-hadley@firstName <- "John"               # Warning
-hadley@first_name
-
-# Properties can have default values that are quoted calls.
-# These become standard function promises in the default constructor,
-# evaluated at the time the object is constructed.
-stopwatch <- new_class("stopwatch", properties = list(
-  starttime = new_property(class = class_POSIXct, default = quote(Sys.time())),
-  totaltime = new_property(getter = function(self)
-    difftime(Sys.time(), self@starttime, units = "secs"))
-))
-args(stopwatch)
-round(stopwatch()@totaltime)
-round(stopwatch(Sys.time() - 1)@totaltime)
-
-# You can make a property required by the constructor either by:
-# - relying on the validator to error with the default value, or by
-# - setting the property default to a quoted error call.
-Person <- new_class("Person", properties = list(
-  name = new_property(class_character, validator = function(value) {
-    if (length(value) != 1 || is.na(value) || value == "")
-      "must be a non-empty string"
-  }))
-)
-try(Person())
-try(Person(1)) # class_character$validator() is also checked.
-Person("Alice")
-
-Person <- new_class("Person", properties = list(
-  name = new_property(class_character,
-                      default = quote(stop("@name is required")))
-))
-try(Person())
-Person("Alice")
-
-# You can mark a property as read-only after construction by
-# providing a custom setter.
-Person <- new_class("Person", properties = list(
-  birth_date = new_property(
-    class_Date,
-    setter = function(self, value) {
-      if(!is.null(self@birth_date)) {
-        stop("@birth_date is read-only", call. = FALSE)
-      }
-      self@birth_date <- as.Date(value)
-      self
-    }
-)))
-person <- Person("1999-12-31")
-try(person@birth_date <- "2000-01-01")
 }

--- a/tests/testthat/_snaps/constructor.md
+++ b/tests/testthat/_snaps/constructor.md
@@ -4,13 +4,19 @@
       new_constructor(S7_object, list())
     Output
       function () 
-      new_object(S7_object())
+      {
+          new_object(S7_object())
+      }
       <environment: namespace:S7>
     Code
       new_constructor(S7_object, as_properties(list(x = class_numeric, y = class_numeric)))
     Output
       function (x = integer(0), y = integer(0)) 
-      new_object(S7_object(), x = x, y = y)
+      {
+          x
+          y
+          new_object(S7_object(), x = x, y = y)
+      }
       <environment: namespace:S7>
     Code
       foo <- new_class("foo", parent = class_character)
@@ -51,13 +57,18 @@
       new_constructor(foo1, list())
     Output
       function () 
-      new_object(S7_object())
+      {
+          new_object(S7_object())
+      }
       <environment: namespace:S7>
     Code
       new_constructor(foo1, as_properties(list(y = class_double)))
     Output
       function (y = numeric(0)) 
-      new_object(S7_object(), y = y)
+      {
+          y
+          new_object(S7_object(), y = y)
+      }
       <environment: namespace:S7>
 
 # can use `...` in parent constructor

--- a/tests/testthat/test-constructor.R
+++ b/tests/testthat/test-constructor.R
@@ -158,3 +158,37 @@ test_that("can create constructors with missing or lazy defaults", {
   expect_error(p@birthdate <- as.Date('1970-01-01'),
                "Can\'t set read-only property Person@birthdate")
 })
+
+
+
+test_that("Dynamic settable properties are included in constructor", {
+  Foo <- new_class(
+    name = "Foo",
+    properties = list(
+      dynamic_settable = new_property(
+        class_numeric,
+        getter = function(self) self@dynamic_settable,
+        setter = function(self, value) {
+          self@dynamic_settable <- value
+          self
+        }
+      ),
+
+      dynamic_read_only = new_property(
+        class_numeric,
+        getter = function(self) 99,
+      )
+    )
+  )
+
+  expect_equal(formals(Foo), pairlist(dynamic_settable = numeric()))
+  expect_equal(Foo()@dynamic_settable, numeric())
+  expect_equal(Foo(3)@dynamic_settable, 3)
+
+  foo <- Foo()
+  expect_error(foo@dynamic_read_only <- 1,
+               "Can't set read-only property <Foo>@dynamic_read_only")
+  foo@dynamic_settable <- 1
+  expect_equal(foo@dynamic_settable, 1)
+
+})

--- a/tests/testthat/test-constructor.R
+++ b/tests/testthat/test-constructor.R
@@ -101,14 +101,15 @@ test_that("can create constructors with missing or lazy defaults", {
   Person <- new_class(
     name = "Person",
     properties = list(
-      # non-dynamic, default missing (required constructor arg)
-      first_name = new_property(class_character, default = quote(expr = )),
+      # non-dynamic, default error call (required constructor arg)
+      first_name = new_property(class_character, default = quote(stop(
+        'argument "first_name" is missing, with no default'))),
 
       # non-dynamic, static default (optional constructor arg)
       middle_name = new_property(class_character, default = ""),
 
-      # non-dynamic, default missing (required constructor arg) (same as first_name)
-      last_name = new_property(class_missing | class_character),
+      # non-dynamic, nullable character
+      last_name = new_property(NULL | class_character),
 
       # non-dynamic, but defaults to the value of another property
       nick_name = new_property(class_character, default = quote(first_name)),
@@ -133,15 +134,15 @@ test_that("can create constructors with missing or lazy defaults", {
   )
 
   expect_equal(formals(Person), as.pairlist(alist(
-    first_name = ,
+    first_name = stop('argument "first_name" is missing, with no default'),
     middle_name = "",
-    last_name = ,
+    last_name = NULL,
     nick_name = first_name,
     birthdate = Sys.Date()
   ))) # no age
 
   expect_error(Person(), 'argument "first_name" is missing, with no default')
-  expect_error(Person("Alice"), 'argument "last_name" is missing, with no default')
+  expect_null(Person("Alice")@last_name)
 
   p <- Person("Alice", ,"Smith")
 

--- a/tests/testthat/test-property.R
+++ b/tests/testthat/test-property.R
@@ -407,8 +407,9 @@ test_that("custom getters don't infinitely recurse", {
     )
   ))
 
+  expect_equal(someclass("foo")@someprop, "FOO")
   x <- someclass()
-  expect_null(x@someprop)
+  expect_equal(x@someprop, character())
   x@someprop <- "foo"
   expect_equal(x@someprop, "FOO")
 
@@ -429,8 +430,11 @@ test_that("custom setters can call custom getters", {
     )
   ))
 
+  x <- someclass("foo")
+  expect_equal(x@someprop, "FOO")
+
   x <- someclass()
-  expect_null(x@someprop)
+  expect_equal(x@someprop, character())
 
   x@someprop <- "foo"
   expect_equal(x@someprop, "FOO")

--- a/vignettes/classes-objects.Rmd
+++ b/vignettes/classes-objects.Rmd
@@ -194,6 +194,24 @@ empty <- new_class("empty",
 empty()
 ```
 
+A quoted call becomes a standard function promise in the default constructor,
+evaluated at the time the object is constructed.
+```{r}
+stopwatch <- new_class("stopwatch", properties = list(
+  start_time = new_property(
+    class = class_POSIXct,  
+    default = quote(Sys.time())
+  ), 
+  elapsed = new_property(
+    getter = function(self) {
+      difftime(Sys.time(), self@start_time, units = "secs")
+    }
+  )
+))
+args(stopwatch)
+round(stopwatch()@elapsed)
+round(stopwatch(Sys.time() - 1)@elapsed)
+```
 ### Computed properties
 
 It's sometimes useful to have a property that is computed on demand.
@@ -224,6 +242,9 @@ x@length <- 20
 ### Dynamic properties
 
 You can make a computed property fully dynamic so that it can be read and written by also supplying a `setter`.
+
+A `setter` is a function with arguments `self` and `value` that returns a modified object.
+
 For example, we could extend the previous example to allow the `@length` to be set, by modifying the `@end` of the vector:
 
 ```{r}
@@ -249,7 +270,103 @@ x@length <- 5
 x
 ```
 
-A `setter` is a function with arguments `self` and `value` that returns a modified object.
+### Common Patterns
+
+`getter`, `setter`, `default`, and `validator` can be used to implement many common patterns of properties.
+
+#### Deprecated properties 
+
+A `setter` + `getter` can be used to to deprecate a property:
+
+```{r}
+Person <- new_class("Person", properties = list(
+ first_name = class_character,
+ firstName = new_property(
+    getter = function(self) {
+      warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
+      self@first_name
+    },
+    setter = function(self, value) {
+      if(is.null(value)) {
+        return(self)
+      }
+      warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
+      self@first_name <- value
+      self
+    }
+  )
+))
+
+hadley <- Person(firstName = "Hadley")   
+
+hadley <- Person(first_name = "Hadley") # no warning
+
+hadley@firstName                       
+
+hadley@firstName <- "John"              
+
+hadley@first_name  # no warning
+```
+
+
+#### Required properties
+
+You can make a property required by the constructor either by:
+
+- relying on the validator to error with the default value, or by
+- setting the property default to a quoted error call.
+
+```{r}
+Person <- new_class("Person", properties = list(
+ name = new_property(class_character, validator = function(value) {
+   if (length(value) != 1 || is.na(value) || value == "")
+     "must be a non-empty string"
+ }))
+)
+
+try(Person())
+
+try(Person(1)) # class_character$validator() is also checked.
+
+Person("Alice")
+```
+
+
+```{r}
+Person <- new_class("Person", properties = list(
+ name = new_property(class_character,
+                     default = quote(stop("@name is required")))
+))
+
+try(Person())
+
+Person("Alice")
+```
+
+
+#### Frozen properties
+
+You can mark a property as read-only after construction by
+providing a custom `setter`.
+
+```{r}
+Person <- new_class("Person", properties = list(
+ birth_date = new_property(
+   class_Date,
+   setter = function(self, value) {
+     if(!is.null(self@birth_date)) {
+       stop("@birth_date is read-only", call. = FALSE)
+     }
+     self@birth_date <- as.Date(value)
+     self
+   }
+)))
+
+person <- Person("1999-12-31")
+
+try(person@birth_date <- "2000-01-01")
+```
+
 
 ## Constructors
 

--- a/vignettes/classes-objects.Rmd
+++ b/vignettes/classes-objects.Rmd
@@ -282,12 +282,14 @@ A `setter` + `getter` can be used to to deprecate a property:
 Person <- new_class("Person", properties = list(
  first_name = class_character,
  firstName = new_property(
+    class_character,
+    default = quote(first_name),
     getter = function(self) {
       warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
       self@first_name
     },
     setter = function(self, value) {
-      if(is.null(value)) {
+      if (identical(value, self@first_name)) {
         return(self)
       }
       warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
@@ -297,7 +299,9 @@ Person <- new_class("Person", properties = list(
   )
 ))
 
-hadley <- Person(firstName = "Hadley")   
+args(Person)
+
+hadley <- Person(firstName = "Hadley")
 
 hadley <- Person(first_name = "Hadley") # no warning
 


### PR DESCRIPTION
This patch implements the idea proposed in [this comment](https://github.com/RConsortium/S7/issues/404#issuecomment-2343826056) and discussed in the last working group (WG) meeting: [summarized here](https://github.com/RConsortium/S7/issues/404#issuecomment-2353411657).

With this change, if a property has a `setter` function, the property will be included as an argument in the default class constructor, and the constructor will call the custom setter for that property.
