### PR TITLE
Accept `initializer` in `new_class()` and `new_property()`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -138,6 +138,7 @@ modify_list <- function (x, new_vals) {
     nms <- names2(new_vals)
     if (!all(nzchar(nms)))
       stop("all elements in `new_vals` must be named")
+    x <- x %||% list()
     x[nms] <- new_vals
   }
 

--- a/man/new_class.Rd
+++ b/man/new_class.Rd
@@ -12,6 +12,7 @@ new_class(
   properties = list(),
   abstract = FALSE,
   constructor = NULL,
+  initializer = NULL,
   validator = NULL
 )
 
@@ -54,6 +55,10 @@ argument for each property.
 A custom constructor should call \code{new_object()} to create the S7 object.
 The first argument, \code{.data}, should be an instance of the parent class
 (if used). The subsequent arguments are used to set the properties.}
+
+\item{initializer}{An optional initializer function. If provided, this
+function is called after \code{constructor()} but before \code{validator()}. It
+should take a single argument, \code{self}.}
 
 \item{validator}{A function taking a single argument, \code{self}, the object
 to validate.

--- a/man/new_property.Rd
+++ b/man/new_property.Rd
@@ -9,6 +9,7 @@ new_property(
   getter = NULL,
   setter = NULL,
   validator = NULL,
+  initializer = NULL,
   default = NULL,
   name = NULL
 )
@@ -38,6 +39,10 @@ beginning of the message.
 
 The validator will be called after the \code{class} has been verified, so
 your code can assume that \code{value} has known type.}
+
+\item{initializer}{An optional initializer function. If provided, this
+function is called when the instance is first constructed, instead of
+\verb{prop<-} (which invokes \code{setter}, if provided).}
 
 \item{default}{When an object is created and the property is not supplied,
 what should it default to? If \code{NULL}, it defaults to the "empty" instance
@@ -92,9 +97,10 @@ try(clock(now = 10))
 args(clock)
 
 # These can be useful if you want to deprecate a property
-person <- new_class("person", properties = list(
+Person <- new_class("Person", properties = list(
   first_name = class_character,
   firstName = new_property(
+     class_character,
      getter = function(self) {
        warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
        self@first_name
@@ -103,13 +109,22 @@ person <- new_class("person", properties = list(
        warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
        self@first_name <- value
        self
+     },
+     initializer = function(self, value) {
+       if (length(value)) {
+         warning("@firstName is deprecated; please use @first_name instead", call. = FALSE)
+         self@first_name <- value # will warn
+       }
+       self@firstName <- character() # for validator
+       self
      }
    )
 ))
-hadley <- person(first_name = "Hadley")
-hadley@firstName
-hadley@firstName <- "John"
-hadley@first_name
+Hadley <- Person(firstName = "Hadley")   # warning
+Hadley <- Person(first_name = "Hadley")
+Hadley@firstName                         # warning
+Hadley@firstName <- "John"               # warning
+Hadley@first_name
 
 # Properties can have default values that are quoted calls.
 # These become standard function promises in the default constructor,

--- a/src/init.c
+++ b/src/init.c
@@ -29,6 +29,7 @@ SEXP sym_package;
 SEXP sym_properties;
 SEXP sym_abstract;
 SEXP sym_constructor;
+SEXP sym_initializer;
 SEXP sym_validator;
 SEXP sym_getter;
 
@@ -52,6 +53,7 @@ void R_init_S7(DllInfo *dll)
     sym_properties = Rf_install("properties");
     sym_abstract = Rf_install("abstract");
     sym_constructor = Rf_install("constructor");
+    sym_initializer = Rf_install("initializer");
     sym_validator = Rf_install("validator");
     sym_getter = Rf_install("getter");
     sym_dot_should_validate = Rf_install(".should_validate");

--- a/src/prop.c
+++ b/src/prop.c
@@ -10,6 +10,7 @@ extern SEXP sym_package;
 extern SEXP sym_properties;
 extern SEXP sym_abstract;
 extern SEXP sym_constructor;
+extern SEXP sym_initializer;
 extern SEXP sym_validator;
 
 extern SEXP ns_S7;
@@ -275,6 +276,7 @@ SEXP prop_(SEXP object, SEXP name) {
           name_sym == sym_properties  ||
           name_sym == sym_abstract  ||
           name_sym == sym_constructor  ||
+          name_sym == sym_initializer  ||
           name_sym == sym_validator))
       return value;
 

--- a/tests/testthat/_snaps/class.md
+++ b/tests/testthat/_snaps/class.md
@@ -19,19 +19,21 @@
        @ package    : NULL
        @ properties :List of 2
        .. $ x: <S7_property> 
-       ..  ..$ name     : chr "x"
-       ..  ..$ class    : <S7_base_class>: <integer>
-       ..  ..$ getter   : NULL
-       ..  ..$ setter   : NULL
-       ..  ..$ validator: NULL
-       ..  ..$ default  : NULL
+       ..  ..$ name       : chr "x"
+       ..  ..$ class      : <S7_base_class>: <integer>
+       ..  ..$ getter     : NULL
+       ..  ..$ setter     : NULL
+       ..  ..$ validator  : NULL
+       ..  ..$ initializer: NULL
+       ..  ..$ default    : NULL
        .. $ y: <S7_property> 
-       ..  ..$ name     : chr "y"
-       ..  ..$ class    : <S7_base_class>: <integer>
-       ..  ..$ getter   : NULL
-       ..  ..$ setter   : NULL
-       ..  ..$ validator: NULL
-       ..  ..$ default  : NULL
+       ..  ..$ name       : chr "y"
+       ..  ..$ class      : <S7_base_class>: <integer>
+       ..  ..$ getter     : NULL
+       ..  ..$ setter     : NULL
+       ..  ..$ validator  : NULL
+       ..  ..$ initializer: NULL
+       ..  ..$ default    : NULL
        @ abstract   : logi FALSE
        @ constructor: function (x = integer(0), y = integer(0))  
        @ validator  : NULL

--- a/tests/testthat/_snaps/property.md
+++ b/tests/testthat/_snaps/property.md
@@ -64,23 +64,25 @@
       print(x)
     Output
       <S7_property> 
-       $ name     : chr "foo"
-       $ class    : <S7_base_class>: <integer>
-       $ getter   : NULL
-       $ setter   : NULL
-       $ validator: NULL
-       $ default  : NULL
+       $ name       : chr "foo"
+       $ class      : <S7_base_class>: <integer>
+       $ getter     : NULL
+       $ setter     : NULL
+       $ validator  : NULL
+       $ initializer: NULL
+       $ default    : NULL
     Code
       str(list(x))
     Output
       List of 1
        $ : <S7_property> 
-        ..$ name     : chr "foo"
-        ..$ class    : <S7_base_class>: <integer>
-        ..$ getter   : NULL
-        ..$ setter   : NULL
-        ..$ validator: NULL
-        ..$ default  : NULL
+        ..$ name       : chr "foo"
+        ..$ class      : <S7_base_class>: <integer>
+        ..$ getter     : NULL
+        ..$ setter     : NULL
+        ..$ validator  : NULL
+        ..$ initializer: NULL
+        ..$ default    : NULL
 
 # properties can be base, S3, S4, S7, or S7 union
 

--- a/tests/testthat/test-constructor.R
+++ b/tests/testthat/test-constructor.R
@@ -117,11 +117,12 @@ test_that("can create constructors with missing or lazy defaults", {
       birthdate = new_property(
         class = class_Date,
         default = quote(Sys.Date()),
-        setter = function(self, value) {
-          if (!is.null(self@birthdate))
-            stop("Can't set read-only property Person@birthdate")
+        initializer = function(self, value) {
           self@birthdate <- value
           self
+        },
+        setter = function(self, value) {
+          stop("Can't set read-only property Person@birthdate")
         }
       ),
 


### PR DESCRIPTION
This PR is a sketch of one possible solution for allowing users some more control over what property `setters` get called at object construction without too much hassle (i.e., without requiring a custom constructor.)

https://github.com/RConsortium/S7/pull/445#issuecomment-2362179831

Now that I look at this, it doesn't seem quite right either. 

Perhaps a `new_property(..., virtual = TRUE)` argument, which would mean the property is not set at construction and is not included as a constructor argument. 