### PR TITLE
Refactor `method-dispatch.c`

### DIFF
--- a/.github/workflows/rchk.yml
+++ b/.github/workflows/rchk.yml
@@ -1,0 +1,23 @@
+name: rchk
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/r-hub/containers/rchk:latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        R -q -e 'pak::pkg_install(c("deps::.", "any::rcmdcheck"), dependencies = TRUE)'
+
+    - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/rchk.yml
+++ b/.github/workflows/rchk.yml
@@ -2,22 +2,34 @@ name: rchk
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+
 
 jobs:
-  check:
+  rchk:
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/r-hub/containers/rchk:latest
-
     steps:
+
     - uses: actions/checkout@v4
 
-    - name: Install dependencies
-      run: |
-        R -q -e 'pak::pkg_install(c("deps::.", "any::rcmdcheck"), dependencies = TRUE)'
+    - uses: r-lib/actions/setup-pandoc@v2
+    - uses: r-lib/actions/setup-r@v2
+    - uses: r-lib/actions/setup-r-dependencies@v2
 
-    - uses: r-lib/actions/check-r-package@v2
+    - run: R CMD build .
+
+    - run: docker pull kalibera/rchk:latest
+
+    - name: run rchk
+      run: |
+          pkgtar=$(ls S7_*.tar.gz)
+          mkdir -p rchk/packages
+          mv $pkgtar rchk/packages/
+          cd rchk
+          docker run -v `pwd`/packages:/rchk/packages kalibera/rchk:latest /rchk/packages/$pkgtar > rchk.log 2>&1
+          cat rchk.log
+
+    - name: upload rchk log
+      uses: actions/upload-artifact@v4
+      with:
+        name: rchk-log
+        path: rchk/rchk.log

--- a/.github/workflows/rchk.yml
+++ b/.github/workflows/rchk.yml
@@ -28,6 +28,9 @@ jobs:
           docker run -v `pwd`/packages:/rchk/packages kalibera/rchk:latest /rchk/packages/$pkgtar > rchk.log 2>&1
           cat rchk.log
 
+    - run: cat rchk.log
+      working-directory: rchk
+
     - name: upload rchk log
       uses: actions/upload-artifact@v4
       with:

--- a/R/method-dispatch.R
+++ b/R/method-dispatch.R
@@ -20,6 +20,5 @@ method_lookup_error_message <- function(name, types) {
 #' @order 2
 #' @export
 S7_dispatch <- function() {
-  S7_dispatched_call <- .Call(method_call_, sys.call(-1), sys.function(-1), sys.frame(-1))
-  eval(S7_dispatched_call, envir = sys.frame(-1))
+  .External2(method_call_, sys.function(-1L), sys.frame(-1L))
 }

--- a/src/init.c
+++ b/src/init.c
@@ -5,23 +5,26 @@
 
 /* .Call calls */
 extern SEXP method_(SEXP, SEXP, SEXP, SEXP);
-extern SEXP method_call_(SEXP, SEXP, SEXP);
+extern SEXP method_call_(SEXP, SEXP, SEXP, SEXP);
+extern SEXP test_call_(SEXP, SEXP, SEXP, SEXP);
 extern SEXP S7_class_(SEXP, SEXP);
 extern SEXP S7_object_(void);
 extern SEXP prop_(SEXP, SEXP);
 extern SEXP prop_set_(SEXP, SEXP, SEXP, SEXP);
 
+#define CALLDEF(name, n)  {#name, (DL_FUNC) &name, n}
+
 static const R_CallMethodDef CallEntries[] = {
-    {"method_", (DL_FUNC) &method_, 4},
-    {"S7_object_", (DL_FUNC) &S7_object_, 0},
-    {"prop_", (DL_FUNC) &prop_, 2},
-    {"prop_set_", (DL_FUNC) &prop_set_, 4},
+    CALLDEF(method_, 4),
+    CALLDEF(S7_object_, 0),
+    CALLDEF(prop_, 2),
+    CALLDEF(prop_set_, 4),
     {NULL, NULL, 0}
 };
 
 static const R_ExternalMethodDef ExternalEntries[] = {
-  {"method_call_", (DL_FUNC) &method_call_, 2},
-  {NULL, NULL, 0}
+    CALLDEF(method_call_, 2),
+    {NULL, NULL, 0}
 };
 
 SEXP sym_ANY;

--- a/src/init.c
+++ b/src/init.c
@@ -13,11 +13,15 @@ extern SEXP prop_set_(SEXP, SEXP, SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
     {"method_", (DL_FUNC) &method_, 4},
-    {"method_call_", (DL_FUNC) &method_call_, 3},
     {"S7_object_", (DL_FUNC) &S7_object_, 0},
     {"prop_", (DL_FUNC) &prop_, 2},
     {"prop_set_", (DL_FUNC) &prop_set_, 4},
     {NULL, NULL, 0}
+};
+
+static const R_ExternalMethodDef ExternalEntries[] = {
+  {"method_call_", (DL_FUNC) &method_call_, 2},
+  {NULL, NULL, 0}
 };
 
 SEXP sym_ANY;
@@ -47,11 +51,11 @@ SEXP ns_S7;
 
 void R_init_S7(DllInfo *dll)
 {
-    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_registerRoutines(dll, NULL, CallEntries, NULL, ExternalEntries);
     R_useDynamicSymbols(dll, FALSE);
+
     sym_ANY = Rf_install("ANY");
     sym_S7_class = Rf_install("S7_class");
-
     sym_name = Rf_install("name");
     sym_parent = Rf_install("parent");
     sym_package = Rf_install("package");
@@ -70,5 +74,8 @@ void R_init_S7(DllInfo *dll)
     fn_base_quote = Rf_eval(Rf_install("quote"), R_BaseEnv);
     fn_base_missing = Rf_eval(Rf_install("missing"), R_BaseEnv);
 
-    ns_S7 = Rf_findVarInFrame(R_NamespaceRegistry, Rf_install("S7"));
+    SEXP S7_str = PROTECT(Rf_mkString("S7"));
+    SEXP getS7ns_call = PROTECT(Rf_lang2(Rf_install("getNamespace"), S7_str));
+    ns_S7 = Rf_eval(getS7ns_call, R_BaseEnv);
+    UNPROTECT(2);
 }

--- a/src/init.c
+++ b/src/init.c
@@ -74,8 +74,5 @@ void R_init_S7(DllInfo *dll)
     fn_base_quote = Rf_eval(Rf_install("quote"), R_BaseEnv);
     fn_base_missing = Rf_eval(Rf_install("missing"), R_BaseEnv);
 
-    SEXP S7_str = PROTECT(Rf_mkString("S7"));
-    SEXP getS7ns_call = PROTECT(Rf_lang2(Rf_install("getNamespace"), S7_str));
-    ns_S7 = Rf_eval(getS7ns_call, R_BaseEnv);
-    UNPROTECT(2);
+    ns_S7 = Rf_findVarInFrame(R_NamespaceRegistry, Rf_install("S7"));
 }

--- a/src/init.c
+++ b/src/init.c
@@ -35,8 +35,12 @@ SEXP sym_getter;
 SEXP sym_dot_should_validate;
 SEXP sym_dot_getting_prop;
 SEXP sym_dot_setting_prop;
+SEXP sym_obj_dispatch;
+SEXP sym_dispatch_args;
+SEXP sym_methods;
 
 SEXP fn_base_quote;
+SEXP fn_base_missing;
 
 SEXP ns_S7;
 
@@ -59,8 +63,12 @@ void R_init_S7(DllInfo *dll)
     sym_dot_should_validate = Rf_install(".should_validate");
     sym_dot_getting_prop = Rf_install(".getting_prop");
     sym_dot_setting_prop = Rf_install(".setting_prop");
+    sym_obj_dispatch = Rf_install("obj_dispatch");
+    sym_dispatch_args = Rf_install("dispatch_args");
+    sym_methods = Rf_install("methods");
 
     fn_base_quote = Rf_eval(Rf_install("quote"), R_BaseEnv);
+    fn_base_missing = Rf_eval(Rf_install("missing"), R_BaseEnv);
 
     ns_S7 = Rf_findVarInFrame(R_NamespaceRegistry, Rf_install("S7"));
 }

--- a/src/init.c
+++ b/src/init.c
@@ -48,6 +48,8 @@ SEXP fn_base_missing;
 
 SEXP ns_S7;
 
+SEXP R_TRUE, R_FALSE;
+
 
 void R_init_S7(DllInfo *dll)
 {
@@ -74,5 +76,7 @@ void R_init_S7(DllInfo *dll)
     fn_base_quote = Rf_eval(Rf_install("quote"), R_BaseEnv);
     fn_base_missing = Rf_eval(Rf_install("missing"), R_BaseEnv);
 
-    ns_S7 = Rf_findVarInFrame(R_NamespaceRegistry, Rf_install("S7"));
+    ns_S7 = Rf_eval(Rf_install("S7"), R_NamespaceRegistry);
+    R_PreserveObject(R_TRUE = Rf_ScalarLogical(1));
+    R_PreserveObject(R_FALSE = Rf_ScalarLogical(0));
 }

--- a/src/method-dispatch.c
+++ b/src/method-dispatch.c
@@ -11,12 +11,15 @@ extern SEXP sym_methods;
 extern SEXP fn_base_quote;
 extern SEXP fn_base_missing;
 
+extern SEXP R_TRUE;
+
+
 // extern Rboolean is_S7_object(SEXP);
 // extern Rboolean is_s7_class(SEXP);
 // extern void check_is_S7(SEXP object);
 
 
-static
+static inline
 SEXP maybe_enquote(SEXP x) {
   switch (TYPEOF(x)) {
     case SYMSXP:
@@ -190,7 +193,9 @@ SEXP method_call_(SEXP call_, SEXP op_, SEXP args_, SEXP env_) {
       if (arg == R_MissingArg ||
          (TYPEOF(arg) == PROMSXP && PRCODE(arg) == R_MissingArg)) {
 
-        SETCDR(mcall_tail, Rf_cons(name, R_NilValue));
+        SEXP node = Rf_cons(arg, R_NilValue);
+        SETCDR(mcall_tail, node);
+        SET_TAG(node, name);
         SET_VECTOR_ELT(dispatch_classes, i, Rf_mkString("MISSING"));
 
       } else { // arg not missing
@@ -218,14 +223,18 @@ SEXP method_call_(SEXP call_, SEXP op_, SEXP args_, SEXP env_) {
           else
             arg = true_val;
 
-          SETCDR(mcall_tail, Rf_cons(arg, R_NilValue));
+          SEXP node = Rf_cons(arg, R_NilValue);
+          SETCDR(mcall_tail, node);
+          SET_TAG(node, name);
           SET_VECTOR_ELT(dispatch_classes, i, VECTOR_ELT(val, 1));
 
         } else { // not a S7_super, a regular value
 
           // A PROMSXP arg will have been updated in place by Rf_eval() above.
           // Add to arguments of method call
-          SETCDR(mcall_tail, Rf_cons(arg, R_NilValue));
+          SEXP node = Rf_cons(arg, R_NilValue);
+          SETCDR(mcall_tail, node);
+          SET_TAG(node, name);
 
           // Determine class string to use for method look up
           SET_VECTOR_ELT(dispatch_classes, i, S7_obj_dispatch(val));

--- a/src/method-dispatch.c
+++ b/src/method-dispatch.c
@@ -15,7 +15,7 @@ extern SEXP R_TRUE;
 
 
 static inline
-void APPEND_NODE(SEXP node, SEXP val, SEXP tag) {
+void APPEND_NODE(SEXP node, SEXP tag, SEXP val) {
   SEXP new_node = Rf_cons(val, R_NilValue);
   SETCDR(node, new_node);
   SET_TAG(new_node, tag);
@@ -194,7 +194,7 @@ SEXP method_call_(SEXP call_, SEXP op_, SEXP args_, SEXP env_) {
       SEXP arg = Rf_findVarInFrame(envir, name);
       if (arg == R_MissingArg) {
 
-        APPEND_NODE(mcall_tail, arg, name);
+        APPEND_NODE(mcall_tail, name, arg);
         SET_VECTOR_ELT(dispatch_classes, i, Rf_mkString("MISSING"));
 
       } else { // arg not missing, is a PROMSXP
@@ -217,8 +217,8 @@ SEXP method_call_(SEXP call_, SEXP op_, SEXP args_, SEXP env_) {
           // substitute() in methods does not retrieve the `super()` call.
           // If we wanted substitute() to work here too, we could do:
           //   if (TYPEOF(arg) == PROMSXP) { SET_PRVALUE(arg, true_val); } else { arg = true_val; }
-          SEXP true_val = VECTOR_ELT(val, 0);
-          APPEND_NODE(mcall_tail, true_val, name);
+          SEXP arg = VECTOR_ELT(val, 0); // true_val used for dispatch
+          APPEND_NODE(mcall_tail, name, arg);
 
           // Put the super() stored class dispatch vector into dispatch_classes
           SET_VECTOR_ELT(dispatch_classes, i, VECTOR_ELT(val, 1));
@@ -227,7 +227,7 @@ SEXP method_call_(SEXP call_, SEXP op_, SEXP args_, SEXP env_) {
 
           // The PROMSXP arg will have been updated in place by Rf_eval() above.
           // Add to arguments of method call
-          APPEND_NODE(mcall_tail, arg, name);
+          APPEND_NODE(mcall_tail, name, arg);
 
           // Determine class string to use for method look up
           SET_VECTOR_ELT(dispatch_classes, i, S7_obj_dispatch(val));
@@ -240,7 +240,7 @@ SEXP method_call_(SEXP call_, SEXP op_, SEXP args_, SEXP env_) {
       } else {
         // pass along the promise so substitute() works
         SEXP arg = Rf_findVarInFrame(envir, name);
-        APPEND_NODE(mcall_tail, arg, name);
+        APPEND_NODE(mcall_tail, name, arg);
       }
     }
 

--- a/src/method-dispatch.c
+++ b/src/method-dispatch.c
@@ -242,10 +242,11 @@ SEXP method_call_(SEXP call_, SEXP op_, SEXP args_, SEXP env_) {
       }
     } else {
       // other arguments not used for dispatch
-      SEXP arg_wrap = Rf_cons(name, R_NilValue);
-      if (name != R_DotsSymbol)
-        SET_TAG(arg_wrap, name);
-      SETCDR(mcall_tail, arg_wrap);
+      if (name == R_DotsSymbol) {
+        SETCDR(mcall_tail, Rf_cons(R_DotsSymbol, R_NilValue));
+      } else {
+        APPEND_NODE(mcall_tail, arg, name);
+      }
     }
 
     mcall_tail = CDR(mcall_tail);

--- a/src/method-dispatch.c
+++ b/src/method-dispatch.c
@@ -63,6 +63,9 @@ SEXP method_rec(SEXP table, SEXP signature, R_xlen_t signature_itr) {
 }
 
 SEXP generic_args(SEXP generic, SEXP envir) {
+  // This function is only used to generate an informative message when
+  // signalling an S7_method_lookup_error, so it doesn't need to be maximally efficient.
+
   // How many arguments are used for dispatch?
   SEXP dispatch_args = Rf_getAttrib(generic, sym_dispatch_args);
   R_xlen_t n_dispatch = Rf_xlength(dispatch_args);
@@ -131,27 +134,6 @@ SEXP method_(SEXP generic, SEXP signature, SEXP envir, SEXP error_) {
   return m;
 }
 
-Rboolean is_missing(SEXP name_sym, SEXP envir) {
-    static SEXP missing_call = NULL;
-    if (missing_call == NULL) {
-      missing_call = Rf_lang2(fn_base_missing, R_NilValue);
-      R_PreserveObject(missing_call);
-    }
-
-    if (TYPEOF(name_sym) != SYMSXP)
-      Rf_error("is_missing() must be called with a symbol");
-    // Update the argument in the static call
-    SETCADR(missing_call, name_sym);
-
-    // Evaluate the call in the provided environment
-    SEXP result = PROTECT(Rf_eval(missing_call, envir));
-
-    // Convert result to Rboolean, handling potential NA case
-    Rboolean is_miss = Rf_asLogical(result);
-
-    UNPROTECT(1);
-    return is_miss;
-}
 
 SEXP S7_obj_dispatch(SEXP object) {
 

--- a/src/method-dispatch.c
+++ b/src/method-dispatch.c
@@ -219,11 +219,11 @@ SEXP method_call_(SEXP call_, SEXP op_, SEXP args_, SEXP env_) {
           // If it's a superclass,
           SEXP true_val = VECTOR_ELT(val, 0);
 
-          // Put the super() stored value into the method call
-          // Note, this means we don't pass along the arg PROMSXP and
-          // then substitute() in methods on args where `super()` is used.
-          // If we wanted substitute() to work to, we could do:
-          //   if (TYPEOF(arg) == PROMSXP) {SET_PRVALUE(arg, true_val)} else {arg = true_val}
+          // Put the super() stored value into the method call.
+          // Note: This means we don't pass along the arg PROMSXP, meaning that
+          // substitute() in methods does not retrieve the `super()` call.
+          // If we wanted substitute() to work here too, we could do:
+          //   if (TYPEOF(arg) == PROMSXP) { SET_PRVALUE(arg, true_val); } else { arg = true_val; }
           arg = true_val;
           APPEND_NODE(mcall_tail, arg, name);
 

--- a/src/method-dispatch.c
+++ b/src/method-dispatch.c
@@ -14,6 +14,13 @@ extern SEXP fn_base_missing;
 extern SEXP R_TRUE;
 
 
+static inline
+void APPEND_NODE(SEXP node, SEXP val, SEXP tag) {
+  SEXP new_node = Rf_cons(val, R_NilValue);
+  SETCDR(node, new_node);
+  SET_TAG(new_node, tag);
+}
+
 // extern Rboolean is_S7_object(SEXP);
 // extern Rboolean is_s7_class(SEXP);
 // extern void check_is_S7(SEXP object);
@@ -193,9 +200,7 @@ SEXP method_call_(SEXP call_, SEXP op_, SEXP args_, SEXP env_) {
       if (arg == R_MissingArg ||
          (TYPEOF(arg) == PROMSXP && PRCODE(arg) == R_MissingArg)) {
 
-        SEXP node = Rf_cons(arg, R_NilValue);
-        SETCDR(mcall_tail, node);
-        SET_TAG(node, name);
+        APPEND_NODE(mcall_tail, arg, name);
         SET_VECTOR_ELT(dispatch_classes, i, Rf_mkString("MISSING"));
 
       } else { // arg not missing
@@ -223,18 +228,14 @@ SEXP method_call_(SEXP call_, SEXP op_, SEXP args_, SEXP env_) {
           else
             arg = true_val;
 
-          SEXP node = Rf_cons(arg, R_NilValue);
-          SETCDR(mcall_tail, node);
-          SET_TAG(node, name);
+          APPEND_NODE(mcall_tail, arg, name);
           SET_VECTOR_ELT(dispatch_classes, i, VECTOR_ELT(val, 1));
 
         } else { // not a S7_super, a regular value
 
           // A PROMSXP arg will have been updated in place by Rf_eval() above.
           // Add to arguments of method call
-          SEXP node = Rf_cons(arg, R_NilValue);
-          SETCDR(mcall_tail, node);
-          SET_TAG(node, name);
+          APPEND_NODE(mcall_tail, arg, name);
 
           // Determine class string to use for method look up
           SET_VECTOR_ELT(dispatch_classes, i, S7_obj_dispatch(val));

--- a/src/method-dispatch.c
+++ b/src/method-dispatch.c
@@ -134,10 +134,9 @@ SEXP method_(SEXP generic, SEXP signature, SEXP envir, SEXP error_) {
     Rf_error("Corrupt S7_generic: @methods isn't an environment");
   }
 
-  Rboolean error = Rf_asLogical(error_);
   SEXP m = method_rec(table, signature, 0);
 
-  if (error && m == R_NilValue) {
+  if (m == R_NilValue && Rf_asLogical(error_)) {
     S7_method_lookup_error(generic, envir);
   }
 
@@ -254,9 +253,7 @@ SEXP method_call_(SEXP call_, SEXP op_, SEXP args_, SEXP env_) {
   }
 
   // Now that we have all the classes, we can look up what method to call
-  SEXP error_if_not_found = PROTECT(Rf_ScalarLogical(1));
-  ++n_protect;
-  SEXP m = method_(generic, dispatch_classes, envir, error_if_not_found);
+  SEXP m = method_(generic, dispatch_classes, envir, R_TRUE);
   SETCAR(mcall, m);
 
   SEXP out = Rf_eval(mcall, envir);

--- a/tests/testthat/_snaps/R-lt-4-3/method-dispatch.md
+++ b/tests/testthat/_snaps/R-lt-4-3/method-dispatch.md
@@ -1,0 +1,8 @@
+# method dispatch works for class_missing
+
+    Code
+      foo_wrapper()
+    Condition
+      Error in `S7::S7_dispatch()`:
+      ! argument "xx" is missing, with no default
+

--- a/tests/testthat/_snaps/method-dispatch.md
+++ b/tests/testthat/_snaps/method-dispatch.md
@@ -49,3 +49,11 @@
       - x: <logical>
       - y: <logical>
 
+# method dispatch works for class_missing
+
+    Code
+      foo_wrapper()
+    Condition
+      Error in `foo_wrapper()`:
+      ! argument "xx" is missing, with no default
+

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -76,6 +76,28 @@ test_that("can substitute() args", {
     method(foo, class_character) <- function(x, ..., z = 1) substitute(z)
   )
   expect_equal(foo("x", z = letters), quote(letters))
+
+  suppressMessages(
+    method(foo, class_character) <- function(x, ..., z = 1) substitute(list(...))
+  )
+  expect_equal(foo("x", abc = xyz), quote(list(abc = xyz)))
+
+  suppressMessages(
+    method(foo, class_character) <- function(x, ..., z = 1, y) missing(y)
+  )
+  expect_true(foo("x"), TRUE)
+  expect_true(foo("x", y =), TRUE)
+    expect_true(foo("x", y =), TRUE)
+
+  suppressMessages(
+    method(foo, class_character) <- function(x, ..., z = 1, y) ...length()
+  )
+
+  expect_equal(foo("x"), 0)
+  expect_equal(foo("x", y =), 0)
+  expect_equal(foo("x", y =, abc), 1)
+  expect_equal(foo("x", y =, abc = xyz), 1)
+  expect_equal(foo("x", y =, abc, xyz), 2)
 })
 
 test_that("methods get values modified in the generic", {

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -220,6 +220,10 @@ test_that("method dispatch works for class_missing", {
 
   # dispatch on class_missing only works directly in the generic call
   foo_wrapper <- function(xx) foo(xx)
-  expect_snapshot(error = TRUE, foo_wrapper())
+  expect_snapshot(
+    error = TRUE,
+    variant = if (getRversion() < "4.3") "R-lt-4-3",
+    foo_wrapper()
+  )
 
 })

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -220,6 +220,6 @@ test_that("method dispatch works for class_missing", {
 
   # dispatch on class_missing only works directly in the generic call
   foo_wrapper <- function(xx) foo(xx)
-  expect_error(foo_wrapper(), 'argument "xx" is missing, with no default')
+  expect_snapshot(error = TRUE, foo_wrapper())
 
 })

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -186,3 +186,17 @@ test_that("can dispatch on evaluated arguments", {
   method(my_generic, class_numeric) <- function(x) 100
   expect_equal(my_generic("x"), 100)
 })
+
+
+test_that("method dispatch works for class_missing", {
+
+  foo <- new_generic("foo", "x")
+  method(foo, class_missing) <- function(x) missing(x)
+
+  expect_true(foo())
+
+  # dispatch on class_missing only works directly in the generic call
+  foo_wrapper <- function(xx) foo(xx)
+  expect_error(foo_wrapper(), 'argument "xx" is missing, with no default')
+
+})

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -72,9 +72,10 @@ test_that("can substitute() args", {
   )
   expect_equal(foo("x", y = letters), quote(letters))
 
-  # Doesn't work currently
-  # method(foo, class_character) <- function(x, ..., z = 1) substitute(z)
-  # expect_equal(foo("x", z = letters), quote(letters))
+  suppressMessages(
+    method(foo, class_character) <- function(x, ..., z = 1) substitute(z)
+  )
+  expect_equal(foo("x", z = letters), quote(letters))
 })
 
 test_that("methods get values modified in the generic", {


### PR DESCRIPTION
This PR has fixes for current `rchk` warning, as well as non-API usage warnings. 

rchk warnings:
https://raw.githubusercontent.com/kalibera/cran-checks/master/rchk/results/S7.out

```r
Package S7 version 0.1.1
Package built using 86189/R 4.4.0; x86_64-pc-linux-gnu; 2024-03-25 22:22:05 UTC; unix   
Checked with rchk version fdc068715daa3a256062cc20e0d4a5157dacc9a4 LLVM version 14.0.6
More information at https://github.com/kalibera/cran-checks/blob/master/rchk/PROTECT.md
For rchk in docker image see https://github.com/kalibera/rchk/blob/master/doc/DOCKER.md

Function S7_obj_dispatch
  [UP] allocating function Rf_findVarInFrame(?,S:obj_dispatch) may destroy its unprotected argument (ns <arg 1>), which is later used. S7/src/method-dispatch.c:111
  [UP] calling allocating function Rf_findVarInFrame(?,S:obj_dispatch) with a fresh pointer (ns <arg 1>) S7/src/method-dispatch.c:111
  [UP] unprotected variable ns while calling allocating function Rf_install S7/src/method-dispatch.c:111
  [UP] unprotected variable ns while calling allocating function Rf_lang2 S7/src/method-dispatch.c:114
  [UP] calling allocating function Rf_eval with a fresh pointer (ns <arg 2>) S7/src/method-dispatch.c:115

Function generic_args
  [UP] calling allocating function Rf_eval with a fresh pointer (arg <arg 1>) S7/src/method-dispatch.c:57

Function method_
  [UP] unprotected variable m while calling allocating function Rf_asInteger S7/src/method-dispatch.c:98

Function method_call_
  [UP] allocating function Rf_eval may destroy its unprotected argument (arg <arg 1>), which is later used. S7/src/method-dispatch.c:158
  [UP] calling allocating function Rf_eval with a fresh pointer (arg <arg 1>) S7/src/method-dispatch.c:158

Function method_rec
  [UP] calling allocating function method_rec with a fresh pointer (val <arg 1>) S7/src/method-dispatch.c:20
  [UP] calling allocating function method_rec with a fresh pointer (val <arg 1>) S7/src/method-dispatch.c:30
```

non-API: https://github.com/RConsortium/S7/issues/471
```
Result: NOTE
  File ‘S7/libs/S7.so’:
    Found non-API calls to R: ‘PRCODE’, ‘SET_PRVALUE’
  
  Compiled code should not call non-API entry points in R.
  
  See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual,
  and section ‘Moving into C API compliance’ for issues with the use of
  non-API entry points.
```