### PR TITLE
Improve `traceback()` for dispatched methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # S7 (development version)
 
+* The call context of a dispatched method (as visible in `sys.calls()` and
+  `traceback()`) no longer includes the inlined method and generic, resulting in
+  more compact and readable tracebacks. The dispatched method call now contains
+  only the method name, which serves as a hint for retrieving the method. For
+  example: `method(my_generic, class_double)`(x=10, ...). (#486)
+  
 * `new_class()` now automatically infers the package name when called from 
   within an R package (#459).
 

--- a/R/generic.R
+++ b/R/generic.R
@@ -189,26 +189,6 @@ methods_rec <- function(x, signature) {
   unlist(methods, recursive = FALSE)
 }
 
-make_method_name <- function(generic, chr_signature) {
-  name <- sprintf("%s@methods$%s",
-                  generic@name,
-                  paste0(chr_signature, collapse = "$"))
-
-  pkgname <- topNamespaceName(environment(generic))
-  if (is.null(pkgname))
-    return(name)
-
-  for (get in c("::", ":::")) {
-    tryCatch({
-      generic2 <- eval(call(get, as.name(pkgname), as.name(generic@name)), baseenv())
-      if (identical(generic, generic2))
-        return(paste0(c(pkgname, get, name), collapse = ""))
-    }, error = function(e) NULL)
-  }
-
-  name
-}
-
 generic_add_method <- function(generic, signature, method) {
   p_tbl <- generic@methods
   chr_signature <- vcapply(signature, class_register)

--- a/R/generic.R
+++ b/R/generic.R
@@ -214,7 +214,7 @@ generic_add_method <- function(generic, signature, method) {
   chr_signature <- vcapply(signature, class_register)
 
   if (is.null(attr(method, "name", TRUE)))
-    attr(method, "name") <- as.name(make_method_name(generic, chr_signature))
+    attr(method, "name") <- as.name(method_signature(generic, signature))
 
   for (i in seq_along(chr_signature)) {
     class_name <- chr_signature[[i]]

--- a/src/init.c
+++ b/src/init.c
@@ -45,6 +45,8 @@ SEXP sym_dot_setting_prop;
 SEXP sym_obj_dispatch;
 SEXP sym_dispatch_args;
 SEXP sym_methods;
+SEXP sym_S7_dispatch;
+SEXP sym_name;
 
 SEXP fn_base_quote;
 SEXP fn_base_missing;
@@ -75,6 +77,8 @@ void R_init_S7(DllInfo *dll)
     sym_obj_dispatch = Rf_install("obj_dispatch");
     sym_dispatch_args = Rf_install("dispatch_args");
     sym_methods = Rf_install("methods");
+    sym_S7_dispatch = Rf_install("S7_dispatch");
+    sym_name = Rf_install("name");
 
     fn_base_quote = Rf_eval(Rf_install("quote"), R_BaseEnv);
     fn_base_missing = Rf_eval(Rf_install("missing"), R_BaseEnv);

--- a/tests/testthat/_snaps/method-dispatch.md
+++ b/tests/testthat/_snaps/method-dispatch.md
@@ -57,3 +57,15 @@
       Error in `foo_wrapper()`:
       ! argument "xx" is missing, with no default
 
+# errors from dispatched methods have reasonable tracebacks
+
+    Code
+      my_generic(10)
+    Condition
+      Error in `my_generic@methods$double`:
+      ! hi
+    Code
+      traceback()
+    Output
+      No traceback available
+

--- a/tests/testthat/_snaps/method-dispatch.md
+++ b/tests/testthat/_snaps/method-dispatch.md
@@ -61,23 +61,30 @@
 
     Code
       my_generic(10)
-    Condition
-      Error in `my_generic@methods$double`:
-      ! hi
-    Code
-      traceback()
     Output
-      No traceback available 
+      [[1]]
+      my_generic(10)
+      
+      [[2]]
+      S7::S7_dispatch()
+      
+      [[3]]
+      `method(my_generic, class_double)`(x = 10, ...)
+      
 
 ---
 
     Code
       my_generic(3, 4)
-    Condition
-      Error in `my_generic@methods$double$double`:
-      ! hi
-    Code
-      traceback()
     Output
-      No traceback available 
+      [[1]]
+      my_generic(3, 4)
+      
+      [[2]]
+      S7::S7_dispatch()
+      
+      [[3]]
+      `method(my_generic, list(class_double, class_double))`(x = 3, 
+          y = 4, ...)
+      
 

--- a/tests/testthat/_snaps/method-dispatch.md
+++ b/tests/testthat/_snaps/method-dispatch.md
@@ -67,5 +67,17 @@
     Code
       traceback()
     Output
-      No traceback available
+      No traceback available 
+
+---
+
+    Code
+      my_generic(3, 4)
+    Condition
+      Error in `my_generic@methods$double$double`:
+      ! hi
+    Code
+      traceback()
+    Output
+      No traceback available 
 

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -228,11 +228,20 @@ test_that("method dispatch works for class_missing", {
 })
 
 test_that("errors from dispatched methods have reasonable tracebacks", {
+
+  get_call_stack <- function(n = 3) {
+    x <- sys.calls()
+    x <- x[-length(x)] # remove get_call_stack()
+    x <- tail(x, n)
+    lapply(x, rlang::zap_srcref)
+  }
+
   my_generic <- new_generic("my_generic", "x")
-  method(my_generic, class_numeric) <- function(x) tail(sys.calls(), 3)
+  method(my_generic, class_numeric) <- function(x) get_call_stack()
   expect_snapshot(my_generic(10))
 
   my_generic <- new_generic("my_generic", c("x", "y"))
-  method(my_generic, list(class_numeric, class_numeric)) <- function(x, y) tail(sys.calls(), 3)
+  method(my_generic, list(class_numeric, class_numeric)) <-
+    function(x, y) get_call_stack()
   expect_snapshot(my_generic(3, 4))
 })

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -229,17 +229,15 @@ test_that("method dispatch works for class_missing", {
 
 test_that("errors from dispatched methods have reasonable tracebacks", {
   my_generic <- new_generic("my_generic", "x")
-  method(my_generic, class_numeric) <- function(x) stop("hi")
-  expect_snapshot(error = TRUE, {
+  method(my_generic, class_numeric) <- function(x) tail(sys.calls(), 3)
+  expect_snapshot({
     my_generic(10)
-    traceback()
   })
 
   my_generic <- new_generic("my_generic", c("x", "y"))
-  method(my_generic, list(class_numeric, class_numeric)) <- function(x, y) stop("hi")
+  method(my_generic, list(class_numeric, class_numeric)) <- function(x, y) tail(sys.calls(), 3)
 
-  expect_snapshot(error = TRUE, {
+  expect_snapshot({
     my_generic(3, 4)
-    traceback()
   })
 })

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -225,6 +225,7 @@ test_that("method dispatch works for class_missing", {
     variant = if (getRversion() < "4.3") "R-lt-4-3",
     foo_wrapper()
   )
+})
 
 test_that("errors from dispatched methods have reasonable tracebacks", {
   my_generic <- new_generic("my_generic", "x")
@@ -237,5 +238,8 @@ test_that("errors from dispatched methods have reasonable tracebacks", {
   my_generic <- new_generic("my_generic", c("x", "y"))
   method(my_generic, list(class_numeric, class_numeric)) <- function(x, y) stop("hi")
 
-  my_generic(3, 4)
+  expect_snapshot(error = TRUE, {
+    my_generic(3, 4)
+    traceback()
+  })
 })

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -233,7 +233,7 @@ test_that("errors from dispatched methods have reasonable tracebacks", {
     x <- sys.calls()
     x <- x[-length(x)] # remove get_call_stack()
     x <- tail(x, n)
-    lapply(x, rlang::zap_srcref)
+    lapply(x, utils::removeSource)
   }
 
   my_generic <- new_generic("my_generic", "x")

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -230,14 +230,9 @@ test_that("method dispatch works for class_missing", {
 test_that("errors from dispatched methods have reasonable tracebacks", {
   my_generic <- new_generic("my_generic", "x")
   method(my_generic, class_numeric) <- function(x) tail(sys.calls(), 3)
-  expect_snapshot({
-    my_generic(10)
-  })
+  expect_snapshot(my_generic(10))
 
   my_generic <- new_generic("my_generic", c("x", "y"))
   method(my_generic, list(class_numeric, class_numeric)) <- function(x, y) tail(sys.calls(), 3)
-
-  expect_snapshot({
-    my_generic(3, 4)
-  })
+  expect_snapshot(my_generic(3, 4))
 })

--- a/tests/testthat/test-method-dispatch.R
+++ b/tests/testthat/test-method-dispatch.R
@@ -226,4 +226,16 @@ test_that("method dispatch works for class_missing", {
     foo_wrapper()
   )
 
+test_that("errors from dispatched methods have reasonable tracebacks", {
+  my_generic <- new_generic("my_generic", "x")
+  method(my_generic, class_numeric) <- function(x) stop("hi")
+  expect_snapshot(error = TRUE, {
+    my_generic(10)
+    traceback()
+  })
+
+  my_generic <- new_generic("my_generic", c("x", "y"))
+  method(my_generic, list(class_numeric, class_numeric)) <- function(x, y) stop("hi")
+
+  my_generic(3, 4)
 })


### PR DESCRIPTION
Currently, printing `traceback()` on an error signaled from a generic dispatched method is extremely verbose, bordering on unreadable. This is because the generic method closure is inlined into the constructed call, which is then deparsed in the traceback.

With this PR, we now construct the method call with a symbol at the head. The name is intentionally non-syntatic to avoid potential clashes with the generic's arguments.

Example evaluating the following at the console: 
```r
library(S7)
my_generic <- new_generic("my_generic", "x")
method(my_generic, class_numeric) <- function(x) stop("hi")
my_generic(10)
traceback()
```

After this PR, it prints:
```r
> library(S7)
my_generic <- new_generic("my_generic", "x")
method(my_generic, class_numeric) <- function(x) stop("hi")
my_generic(10)
Error in `my_generic@methods$double`(x = 10, ...) : hi
> traceback()
4: stop("hi") at #1
3: `my_generic@methods$double`(x = 10, ...) at method-dispatch.R#23
2: S7::S7_dispatch()
1: my_generic(10)
```


Presently prints:
```r
> library(S7)
my_generic <- new_generic("my_generic", "x")
method(my_generic, class_numeric) <- function(x) stop("hi")
my_generic(10)
Error in (function (x)  : hi

> traceback()
4: stop("hi") at #1
3: (structure(function (x) 
   stop("hi"), class = c("S7_method", "function", "S7_object"), S7_class = structure(function (.data = function() NULL, 
       generic = (function (.data = function() NULL, name = character(0), 
           methods = new.env(parent = emptyenv()), dispatch_args = character(0)) 
       new_object(fun(.data = .data), name = name, methods = methods, 
           dispatch_args = dispatch_args))(), signature = list()) 
   new_object(fun(.data = .data), generic = generic, signature = signature), name = "S7_method", parent = structure(list(
       class = "function", constructor_name = "fun", constructor = function (.data = function() NULL) 
       .data, validator = function (object) 
       {
           if (base_class(object) != name) {
               sprintf("Underlying data must be <%s> not <%s>", 
                   name, base_class(object))
           }
       }), class = "S7_base_class"), properties = list(generic = structure(list(
       name = "generic", class = structure(function (.data = function() NULL, 
           name = character(0), methods = new.env(parent = emptyenv()), 
           dispatch_args = character(0)) 
       new_object(fun(.data = .data), name = name, methods = methods, 
           dispatch_args = dispatch_args), name = "S7_generic", parent = structure(list(
           class = "function", constructor_name = "fun", constructor = function (.data = function() NULL) 
           .data, validator = function (object) 
           {
               if (base_class(object) != name) {
                   sprintf("Underlying data must be <%s> not <%s>", 
                     name, base_class(object))
               }
           }), class = "S7_base_class"), properties = list(name = structure(list(
           name = "name", class = structure(list(class = "character", 
               constructor_name = "character", constructor = function (.data = character(0)) 
               .data, validator = function (object) 
               {
                   if (base_class(object) != name) {
                     sprintf("Underlying data must be <%s> not <%s>", 
                       name, base_class(object))
                   }
               }), class = "S7_base_class"), getter = NULL, setter = NULL, 
           validator = NULL, default = NULL), class = "S7_property"), 
           methods = structure(list(name = "methods", class = structure(list(
               class = "environment", constructor_name = "environment", 
               constructor = function (.data = new.env(parent = emptyenv())) 
               .data, validator = function (object) 
               {
                   if (base_class(object) != name) {
                     sprintf("Underlying data must be <%s> not <%s>", 
                       name, base_class(object))
                   }
               }), class = "S7_base_class"), getter = NULL, setter = NULL, 
               validator = NULL, default = NULL), class = "S7_property"), 
           dispatch_args = structure(list(name = "dispatch_args", 
               class = structure(list(class = "character", constructor_name = "character", 
                   constructor = function (.data = character(0)) 
                   .data, validator = function (object) 
                   {
                     if (base_class(object) != name) {
                       sprintf("Underlying data must be <%s> not <%s>", 
                         name, base_class(object))
                     }
                   }), class = "S7_base_class"), getter = NULL, 
               setter = NULL, validator = NULL, default = NULL), class = "S7_property")), abstract = FALSE, constructor = function (.data = function() NULL, 
           name = character(0), methods = new.env(parent = emptyenv()), 
           dispatch_args = character(0)) 
       new_object(fun(.data = .data), name = name, methods = methods, 
           dispatch_args = dispatch_args), class = c("S7_class", 
       "S7_object")), getter = NULL, setter = NULL, validator = NULL, 
       default = NULL), class = "S7_property"), signature = structure(list(
       name = "signature", class = structure(list(class = "list", 
           constructor_name = "list", constructor = function (.data = list()) 
           .data, validator = function (object) 
           {
               if (base_class(object) != name) {
                   sprintf("Underlying data must be <%s> not <%s>", 
                     name, base_class(object))
               }
           }), class = "S7_base_class"), getter = NULL, setter = NULL, 
       validator = NULL, default = NULL), class = "S7_property")), abstract = FALSE, constructor = function (.data = function() NULL, 
       generic = (function (.data = function() NULL, name = character(0), 
           methods = new.env(parent = emptyenv()), dispatch_args = character(0)) 
       new_object(fun(.data = .data), name = name, methods = methods, 
           dispatch_args = dispatch_args))(), signature = list()) 
   new_object(fun(.data = .data), generic = generic, signature = signature), class = c("S7_class", 
   "S7_object")), generic = structure(function (x, ...) 
   S7::S7_dispatch(), class = c("S7_generic", "function", "S7_object"
   ), S7_class = structure(function (.data = function() NULL, name = character(0), 
       methods = new.env(parent = emptyenv()), dispatch_args = character(0)) 
   new_object(fun(.data = .data), name = name, methods = methods, 
       dispatch_args = dispatch_args), name = "S7_generic", parent = structure(list(
       class = "function", constructor_name = "fun", constructor = function (.data = function() NULL) 
       .data, validator = function (object) 
       {
           if (base_class(object) != name) {
               sprintf("Underlying data must be <%s> not <%s>", 
                   name, base_class(object))
           }
       }), class = "S7_base_class"), properties = list(name = structure(list(
       name = "name", class = structure(list(class = "character", 
           constructor_name = "character", constructor = function (.data = character(0)) 
           .data, validator = function (object) 
           {
               if (base_class(object) != name) {
                   sprintf("Underlying data must be <%s> not <%s>", 
                     name, base_class(object))
               }
           }), class = "S7_base_class"), getter = NULL, setter = NULL, 
       validator = NULL, default = NULL), class = "S7_property"), 
       methods = structure(list(name = "methods", class = structure(list(
           class = "environment", constructor_name = "environment", 
           constructor = function (.data = new.env(parent = emptyenv())) 
           .data, validator = function (object) 
           {
               if (base_class(object) != name) {
                   sprintf("Underlying data must be <%s> not <%s>", 
                     name, base_class(object))
               }
           }), class = "S7_base_class"), getter = NULL, setter = NULL, 
           validator = NULL, default = NULL), class = "S7_property"), 
       dispatch_args = structure(list(name = "dispatch_args", class = structure(list(
           class = "character", constructor_name = "character", 
           constructor = function (.data = character(0)) 
           .data, validator = function (object) 
           {
               if (base_class(object) != name) {
                   sprintf("Underlying data must be <%s> not <%s>", 
                     name, base_class(object))
               }
           }), class = "S7_base_class"), getter = NULL, setter = NULL, 
           validator = NULL, default = NULL), class = "S7_property")), abstract = FALSE, constructor = function (.data = function() NULL, 
       name = character(0), methods = new.env(parent = emptyenv()), 
       dispatch_args = character(0)) 
   new_object(fun(.data = .data), name = name, methods = methods, 
       dispatch_args = dispatch_args), class = c("S7_class", "S7_object"
   )), name = "my_generic", methods = <environment>, dispatch_args = "x"), signature = list(
       structure(list(class = "double", constructor_name = "double", 
           constructor = function (.data = numeric(0)) 
           .data, validator = function (object) 
           {
               if (base_class(object) != name) {
                   sprintf("Underlying data must be <%s> not <%s>", 
                     name, base_class(object))
               }
           }), class = "S7_base_class"))))(x = 10, ...) at method-dispatch.R#23
2: S7::S7_dispatch()
1: my_generic(10)
```
  