### PR TITLE
Vignette typos fixes

### DIFF
--- a/vignettes/classes-objects.Rmd
+++ b/vignettes/classes-objects.Rmd
@@ -257,6 +257,7 @@ Range <- new_class("Range",
       class = class_double,
       getter = function(self) self@end - self@start,
       setter = function(self, value) {
+        if (length(value) == 0) return(self)
         self@end <- self@start + value
         self
       }

--- a/vignettes/classes-objects.Rmd
+++ b/vignettes/classes-objects.Rmd
@@ -257,7 +257,11 @@ Range <- new_class("Range",
       class = class_double,
       getter = function(self) self@end - self@start,
       setter = function(self, value) {
-        if (length(value) == 0) return(self)
+        if (!length(value)) {
+          # Do nothing if called with the constructor default
+          # value for this property, a zero-length double vector.
+          return(self)
+        }
         self@end <- self@start + value
         self
       }
@@ -393,8 +397,8 @@ Range <- new_class("Range",
     end = class_numeric
   ),
   constructor = function(x) {
-    new_object(S7_object(), 
-               start = min(x, na.rm = TRUE), 
+    new_object(S7_object(),
+               start = min(x, na.rm = TRUE),
                end = max(x, na.rm = TRUE))
   }
 )

--- a/vignettes/classes-objects.Rmd
+++ b/vignettes/classes-objects.Rmd
@@ -24,7 +24,7 @@ library(S7)
 ## Validation
 
 S7 classes can have an optional **validator** that checks that the values of the properties are OK.
-A validator is a function that takes the object (called `self`) and returns `NULL` if its valid or returns a character vector listing the problems.
+A validator is a function that takes the object (called `self`) and returns `NULL` if it's valid or returns a character vector listing the problems.
 
 ### Basics
 
@@ -168,7 +168,7 @@ This makes it possible to use the same property definition for multiple properti
 
 ### Default value
 
-The defaults of `new_class()` create an class that can be constructed with no arguments:
+The defaults of `new_class()` create a class that can be constructed with no arguments:
 
 ```{r}
 Empty <- new_class("Empty",
@@ -225,7 +225,7 @@ Range <- new_class("Range",
     start = class_double,
     end = class_double,
     length = new_property(
-      getter = function(self) self@end - self@start,
+      getter = function(self) self@end - self@start
     )
   )
 )
@@ -398,7 +398,7 @@ Range <- new_class("Range",
   }
 )
 
-range(c(10, 5, 0, 2, 5, 7))
+Range(c(10, 5, 0, 2, 5, 7))
 ```
 
 A constructor must always end with a call to `new_object()`.

--- a/vignettes/compatibility.Rmd
+++ b/vignettes/compatibility.Rmd
@@ -75,14 +75,14 @@ rle <- function(x) {
   }
   n <- length(x)
   if (n == 0L) {
-    new_rle(integer(), x)
+    rle2(integer(), x)
   } else {
     y <- x[-1L] != x[-n]
     i <- c(which(y | is.na(y)), n)
-    new_rle(diff(c(0L, i)), x[i])
+    rle2(diff(c(0L, i)), x[i])
   }
 }
-new_rle <- function(lengths, values) {
+rle2 <- function(lengths, values) {
   structure(
     list(
       lengths = lengths,
@@ -97,7 +97,7 @@ There are two ways to convert this to S7.
 You could keep the structure exactly the same, using a `list` as the underlying data structure and using a constructor to enforce the structure:
 
 ```{r}
-new_rle <- new_class("rle",
+rle2 <- new_class("rle",
   parent = class_list,
   constructor = function(lengths, values) {
     new_object(list(lengths = lengths, values = values))
@@ -109,7 +109,7 @@ rle(1:10)
 Alternatively you could convert it to the most natural representation using S7:
 
 ```{r}
-new_rle <- new_class("rle", properties = list(
+rle2 <- new_class("rle", properties = list(
   lengths = class_integer,
   values = class_atomic
 ))
@@ -118,7 +118,7 @@ new_rle <- new_class("rle", properties = list(
 To allow existing methods to work you'll need to override `$` to access properties instead of list elements:
 
 ```{r}
-method(`$`, new_rle) <- prop
+method(`$`, rle2) <- prop
 rle(1:10)
 ```
 

--- a/vignettes/compatibility.Rmd
+++ b/vignettes/compatibility.Rmd
@@ -109,7 +109,7 @@ rle(1:10)
 Alternatively you could convert it to the most natural representation using S7:
 
 ```{r}
-rle <- new_class("rle", properties = list(
+new_rle <- new_class("rle", properties = list(
   lengths = class_integer,
   values = class_atomic
 ))
@@ -118,7 +118,7 @@ rle <- new_class("rle", properties = list(
 To allow existing methods to work you'll need to override `$` to access properties instead of list elements:
 
 ```{r}
-method(`$`, rle) <- prop
+method(`$`, new_rle) <- prop
 rle(1:10)
 ```
 

--- a/vignettes/compatibility.Rmd
+++ b/vignettes/compatibility.Rmd
@@ -75,14 +75,14 @@ rle <- function(x) {
   }
   n <- length(x)
   if (n == 0L) {
-    rle2(integer(), x)
+    new_rle(integer(), x)
   } else {
     y <- x[-1L] != x[-n]
     i <- c(which(y | is.na(y)), n)
-    rle2(diff(c(0L, i)), x[i])
+    new_rle(diff(c(0L, i)), x[i])
   }
 }
-rle2 <- function(lengths, values) {
+new_rle <- function(lengths, values) {
   structure(
     list(
       lengths = lengths,
@@ -97,7 +97,7 @@ There are two ways to convert this to S7.
 You could keep the structure exactly the same, using a `list` as the underlying data structure and using a constructor to enforce the structure:
 
 ```{r}
-rle2 <- new_class("rle",
+new_rle <- new_class("rle",
   parent = class_list,
   constructor = function(lengths, values) {
     new_object(list(lengths = lengths, values = values))
@@ -109,7 +109,7 @@ rle(1:10)
 Alternatively you could convert it to the most natural representation using S7:
 
 ```{r}
-rle2 <- new_class("rle", properties = list(
+new_rle <- new_class("rle", properties = list(
   lengths = class_integer,
   values = class_atomic
 ))
@@ -118,7 +118,7 @@ rle2 <- new_class("rle", properties = list(
 To allow existing methods to work you'll need to override `$` to access properties instead of list elements:
 
 ```{r}
-method(`$`, rle2) <- prop
+method(`$`, new_rle) <- prop
 rle(1:10)
 ```
 

--- a/vignettes/generics-methods.Rmd
+++ b/vignettes/generics-methods.Rmd
@@ -114,7 +114,7 @@ simple_print(list(1, 2, "x"), diggits = 3)
 
 Occasional it's useful to create a generic without `…` because such functions have a useful property: if a call succeeds for one type of input, it will succeed for any type of input.
 To create such a generic, you'll need to use the third argument to `new_generic()`: an optional function that powers the generic.
-This function has one key property: it must call `call_method()` to actually perform dispatch.
+This function has one key property: it must call `S7_dispatch()` to actually perform dispatch.
 
 In general, this property is only needed for very low-level functions with precisely defined semantics.
 A good example of such a function is `length()`:
@@ -126,7 +126,7 @@ length <- new_generic("length", "x", function(x) {
 ```
 
 Omitting `…` from the generic signature is a strong restriction as it prevents methods from adding extra arguments.
-For this reason, it's should only be used in special situations.
+For this reason, it should only be used in special situations.
 
 ## Customizing generics
 
@@ -137,7 +137,7 @@ display <- new_generic("display", "x")
 S7_data(display)
 ```
 
-The most important part of the body is `S7_dispatch()`; this function finds the method the matches the arguments used for dispatch and calls it with the arguments supplied to the generic.
+The most important part of the body is `S7_dispatch()`; this function finds the method that matches the arguments used for dispatch and calls it with the arguments supplied to the generic.
 
 It can be useful to customize this body.
 The previous section showed one case when you might want to supply the body yourself: dropping `…` from the formals of the generic.
@@ -147,7 +147,7 @@ There are three other useful cases:
 -   To add optional arguments.
 -   Perform some standard work.
 
-A custom `fun` must always include a call to `call_method()`, which will usually be the last call.
+A custom `fun` must always include a call to `S7_dispatch()`, which will usually be the last call.
 
 ### Add required arguments
 
@@ -213,7 +213,7 @@ The only downside to performing error checking is that you constraint the interf
 
 ## `super()`
 
-Sometimes it's useful to define a method for in terms of its superclass.
+Sometimes it's useful to define a method for a class that relies on its superclass.
 A good example of this is computing the mean of a date --- since dates represent the number of days since 1970-01-01, computing the mean is just a matter of computing the mean of the underlying numeric vector and converting it back to a date.
 
 To demonstrate this idea, I'll first define a mean generic with a method for numbers:
@@ -256,8 +256,8 @@ This explicitness makes the code easier to understand and will eventually enable
 
 ## Multiple dispatch
 
-So far we have focused primarily on single dispatch, i.e. generics where `dispatch_on` is a single string.
-It is also possible to supply a length 2 (or more!) vector `dispatch_on` to create a generic that performs multiple dispatch, i.e. it uses the classes of more than one object to find the appropriate method.
+So far we have focused primarily on single dispatch, i.e. generics where `dispatch_args` is a single string.
+It is also possible to supply a length 2 (or more!) vector `dispatch_args` to create a generic that performs multiple dispatch, i.e. it uses the classes of more than one object to find the appropriate method.
 
 Multiple dispatch is a feature primarily of S4, although S3 includes some limited special cases for arithmetic operators.
 Multiple dispatch is heavily used in S4; we don't expect it to be heavily used in S7, but it is occasionally useful.


### PR DESCRIPTION
A few grammatical fixes, updates of old function / argument names, and example code updates in 3 vignettes.

Regarding code updates:

#### `classes-objects.Rmd`

In the example that included a `getter` and a `setter` for the `Range` class, the `setter` was getting called on object instantiation. This resulted in the supplied value of `@end` being overridden to an empty vector because `@length`'s default value is empty. The resulting output of `Range(start = 1, end = 10)` was this:

``` .r
<Range>
 @ start : num 1
 @ end   : num(0) # should be 10
 @ length: num(0) # should be 9
```

I updated the length `setter` to short circuit and return the original object when `value` is empty, and that gave me the correct output. I wanted to call this out because the maintainers might have a better solution in mind for handling instantiation matters like this.

#### `compatibility.Rmd`

I noticed that the more natural representation of the `rle` class using S7 was overwriting the `rle()` function, and this was creating incorrect output for `rle(1:10)`. 

``` .r
Run Length Encoding
  lengths: int [1:10] 1 2 3 4 5 6 7 8 9 10 # should be all 1's
  values : logi(0) # should be 1-10
```

I used the name `new_rle` here instead that seemed to clean things up.